### PR TITLE
正規化ルールに誤った型名が与えられた時に例外を投げるようにする

### DIFF
--- a/src/main/kotlin/io/github/durun/nitron/core/NitronException.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/NitronException.kt
@@ -1,0 +1,7 @@
+package io.github.durun.nitron.core
+
+abstract class NitronException(message: String): Exception(message)
+
+class InvalidTypeException(types: Collection<String>): NitronException(
+		message = "Invalid type: ${types.joinToString(", ")}"
+)

--- a/src/main/kotlin/io/github/durun/nitron/core/ast/visitor/AstIgnoreVisitor.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/ast/visitor/AstIgnoreVisitor.kt
@@ -1,5 +1,6 @@
 package io.github.durun.nitron.core.ast.visitor
 
+import io.github.durun.nitron.core.InvalidTypeException
 import io.github.durun.nitron.core.ast.node.*
 
 fun astIgnoreVisitorOf(ignoreTypes: List<String>): AstIgnoreVisitor {
@@ -44,7 +45,15 @@ private class StringAstIgnoreVisitor(
 private class FastAstIgnoreVisitor(
         private val ignoreRules: Set<NodeType>
 ) : AstIgnoreVisitor() {
-    constructor(types: NodeTypePool, ignoreTypes: List<String>) : this(types.filterRulesAndTokenTypes(ignoreTypes))
+    constructor(types: NodeTypePool, ignoreTypes: List<String>) : this(
+            types.also { _ ->
+                val invalidTypes = ignoreTypes.filter { types.getType(it) == null }
+                if (invalidTypes.isNotEmpty()) {
+                    throw InvalidTypeException(invalidTypes)
+                }
+            }.filterRulesAndTokenTypes(ignoreTypes)
+    )
+
     constructor(types: NodeTypePool) : this(types.allTypes)
 
     override fun shouldIgnore(node: AstRuleNode) = ignoreRules.contains(node.type)

--- a/src/main/kotlin/io/github/durun/nitron/core/ast/visitor/AstSplitVisitor.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/ast/visitor/AstSplitVisitor.kt
@@ -1,5 +1,6 @@
 package io.github.durun.nitron.core.ast.visitor
 
+import io.github.durun.nitron.core.InvalidTypeException
 import io.github.durun.nitron.core.ast.node.*
 
 fun astSplitVisitorOf(splitTypes: List<String>): AstSplitVisitor {
@@ -50,7 +51,13 @@ private class StringAstSplitVisitor(
 private class FastAstSplitVisitor(
         private val splitRules: Set<NodeType>
 ) : AstSplitVisitor() {
-    constructor(types: NodeTypePool, splitRules: List<String>) : this(types.filterRulesAndTokenTypes(splitRules))
+    constructor(types: NodeTypePool, splitRules: List<String>) : this(types.let { types ->
+        val invalidTypes = splitRules.filter { types.getType(it) == null }
+        if (invalidTypes.isNotEmpty()) {
+            throw InvalidTypeException(invalidTypes)
+        }
+        types.filterRulesAndTokenTypes(splitRules)
+    })
     constructor(types: NodeTypePool) : this(types.allTypes)
 
     override fun hasSplitRule(node: AstNode?): Boolean {


### PR DESCRIPTION
#35 の修正