### PR TITLE
JavaScriptの新しい抽出ルール

### DIFF
--- a/config/lang/javascript.json
+++ b/config/lang/javascript.json
@@ -26,7 +26,9 @@
         "BooleanLiteral": "$L"
       },
       "indexedMapping": {
-        "Identifier": "$V"
+        "//singleExpression[./*[@tag='Dot']]/*[1]": "$V",
+        "//identifier[../../*[2]/@tag!='arguments' and ../../*[2]/@tag!='Dot']": "$V",
+        "//argument/singleExpression[./*[@tag!='Dot']]/identifier": "$V"
       },
       "ignoreRules": [
         "importStatement",

--- a/config/nitron.json
+++ b/config/nitron.json
@@ -1,13 +1,13 @@
 {
     "langConfigFiles": {
-        "java": "lang/java.json",
-        "kotlin": "lang/kotlin.json",
-        "python": "lang/python.json",
-        "C#": "lang/csharp.json",
-        "r":  "lang/r.json",
-        "javascript":  "lang/javascript.json",
-        "swift":  "lang/swift3.json",
-        "matlab":  "lang/matlab.json",
-        "erlang":  "lang/erlang.json"
+      "java": "lang/java.json",
+      "kotlin": "lang/kotlin.json",
+      "python": "lang/python.json",
+      "csharp": "lang/csharp.json",
+      "r": "lang/r.json",
+      "javascript": "lang/javascript.json",
+      "swift": "lang/swift3.json",
+      "matlab": "lang/matlab.json",
+      "erlang": "lang/erlang.json"
     }
 }

--- a/src/main/kotlin/io/github/durun/nitron/app/AstPrintCommand.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/AstPrintCommand.kt
@@ -53,12 +53,13 @@ class AstPrintCommand : CliktCommand(
                 utilityJavaFiles = config.grammar.utilJavaFilePaths
         )
         inputs
-                .forEach { input ->
-                    val tree = parser.parse(input.bufferedReader(), config.grammar.startRule)
-                    val ast = tree.accept(AstBuildVisitor(grammarName = config.fileName, parser = parser.antlrParser))
-                    val text = ast.accept(AstPrintVisitor)
-                    output.appendLine("\n@ ${input.path}")
-                    output.appendLine(text)
-                }
+            .forEach { input ->
+                val tree = parser.parse(input.bufferedReader(), config.grammar.startRule)
+                val ast = tree.accept(AstBuildVisitor(grammarName = config.fileName, parser = parser.antlrParser))
+                val text = ast.accept(AstPrintVisitor)
+                output.appendLine("\n@ ${input.path}")
+                output.appendLine(text)
+            }
+        output.flush()
     }
 }

--- a/src/main/kotlin/io/github/durun/nitron/app/CodeNormalizeCommand.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/CodeNormalizeCommand.kt
@@ -49,11 +49,12 @@ class CodeNormalizeCommand : CliktCommand(
         val config = LangConfigLoader.load(configPath)
         val processor = CodeProcessor(config)
         inputs
-                .forEach { input ->
-                    val text = processor.processText(input.readText())
-                    output.appendLine("\n@ ${input.path}")
-                    output.appendLine(text)
-                }
+            .forEach { input ->
+                val text = processor.processText(input.readText())
+                output.appendLine("\n@ ${input.path}")
+                output.appendLine(text)
+            }
+        output.flush()
     }
 
 	@ExperimentalPathApi

--- a/src/main/kotlin/io/github/durun/nitron/core/ast/path/AstPath.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/ast/path/AstPath.kt
@@ -77,10 +77,11 @@ private class AstXPath(expression: String) : AstPath() {
 		val nodes: List<Node> = xpath.selectNodes(root.toXml()).filterIsInstance<Node>()
 		nodes.forEach {
 			val path = it.getIndexPath().drop(1)
-			if (path.isEmpty()) return replacement(root)
-			val parent = root.resolve(path.dropLast(1)) as BasicAstRuleNode
-			val childIndex = path.last()
-			parent.children[childIndex] = replacement(parent.children[childIndex])
+            if (path.isEmpty()) return replacement(root)
+            val childIndex = path.last()
+            when (val parent = root.resolve(path.dropLast(1))) {
+                is BasicAstRuleNode -> parent.children[childIndex] = replacement(parent.children[childIndex])
+            }
 		}
 		return root
 	}

--- a/src/main/kotlin/io/github/durun/nitron/core/ast/visitor/AstXmlBuildVisitor.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/ast/visitor/AstXmlBuildVisitor.kt
@@ -13,13 +13,15 @@ object AstXmlBuildVisitor : AstVisitor<String> {
     override fun visitRule(node: AstRuleNode): String {
         val tag = node.type.name
         val children = node.children.orEmpty().joinToString("") { it.accept(this) }
-        return if (children.isNotEmpty()) "<$tag>${children}</$tag>"
-        else "<$tag>${node.getText()}</$tag>"
+        return if (children.isNotEmpty())
+            """<$tag tag="$tag">${children}</$tag>"""
+        else
+            """<$tag tag="$tag">${node.getText()}</$tag>"""
     }
 
     override fun visitTerminal(node: AstTerminalNode): String {
         val tag = node.type.name
         val value = StringEscapeUtils.escapeXml10(node.token)
-        return """<$tag>$value</$tag>"""
+        return """<$tag tag="$tag">$value</$tag>"""
     }
 }

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/GenericParserTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/GenericParserTest.kt
@@ -8,26 +8,31 @@ import io.kotest.core.spec.style.freeSpec
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import java.nio.file.Paths
 import kotlin.io.path.ExperimentalPathApi
-import kotlin.io.path.readText
 
 @ExperimentalPathApi
 class GenericParserTest : FreeSpec({
 	val configPath = Paths.get("config/nitron.json")
-	val config = NitronConfigLoader.load(configPath)
+    val config = NitronConfigLoader.load(configPath)
 
-	include(tests("javascript",
-			config.langConfig["javascript"]!!.grammar,
-			src = """console.log("Hello");"""
-	))
+    include(
+        tests(
+            "javascript",
+            config.langConfig["javascript"]!!.grammar,
+            src = """console.log("Hello");"""
+        )
+    )
 
-	include(tests("C#",
-			config.langConfig["C#"]!!.grammar,
-			src = """
+    include(
+        tests(
+            "csharp",
+            config.langConfig["csharp"]!!.grammar,
+            src = """
 				class HelloClass {
 				    void hello() { }
 				}
 			""".trimIndent()
-	))
+        )
+    )
 })
 
 @ExperimentalPathApi

--- a/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
@@ -56,16 +56,13 @@ fun langTestFactory(lang: String, config: LangConfig) = freeSpec {
 		}
 		"uses correct rule/token name" {
 			val usedRules: List<String> = (
-					config.process.normalizeConfig.ignoreRules +
-							config.process.normalizeConfig.mapping.keys +
-							config.process.normalizeConfig.indexedMapping.keys +
-							config.process.splitConfig.splitRules
-					).flatMap {
-					when {
-						it.contains("[^a-zA-Z/]") -> null
-						else -> it.split('/').filter(String::isNotEmpty)
-					}
-				}
+                    config.process.normalizeConfig.ignoreRules +
+                            config.process.normalizeConfig.mapping.keys +
+                            config.process.normalizeConfig.indexedMapping.keys +
+                            config.process.splitConfig.splitRules
+                    )
+                .flatMap { it.split('/').filter(String::isNotEmpty) }
+                .filterNot { it.contains(Regex("[^a-zA-Z]")) }
 			val antlrParser = parser!!.antlrParser
 			val allowedRules = antlrParser.ruleNames + antlrParser.tokenTypeMap.keys
 			runCatching {


### PR DESCRIPTION
一部のidentifierが$Vへ正規化されないようになります。
正規化例
```
method(a) → method ( $V0 )
variable.member(variable2.member) → $V0 . member ( $V1 . member )
```