### PR TITLE
Kotlin用の新しい抽出ルール

### DIFF
--- a/config/lang/kotlin.json
+++ b/config/lang/kotlin.json
@@ -21,13 +21,14 @@
 				"RealLiteral": "N"
 			},
 			"indexedMapping": {
-				"atomicExpression/simpleIdentifier": "$V",
-				"variableDeclaration/simpleIdentifier": "$V"
-			},
+              "//postfixUnaryExpression[../*[1]/.[@tag!='memberAccessOperator'] and ./*[2]/*/*[@tag!='valueArguments']]/*[1]/simpleIdentifier": "$V"
+            },
 			"ignoreRules": [
-				"annotation",
-				"preamble"
-			]
+              "annotation",
+              "preamble",
+              "NL",
+              "EOF"
+            ]
 		}
 	}
 }

--- a/config/lang/kotlin.json
+++ b/config/lang/kotlin.json
@@ -1,15 +1,17 @@
 {
-    "extensions": [".kt"],
-	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/kotlin/kotlin/KotlinLexer.g4",
-			"../grammars/kotlin/kotlin/KotlinParser.g4",
-			"../grammars/kotlin/kotlin/UnicodeClasses.g4"
-		],
-		"utilJavaFiles": [],
-		"startRule": "kotlinFile"
-	},
-	"processConfig": {
+  "extensions": [
+	".kt"
+  ],
+  "grammarConfig": {
+	"grammarFiles": [
+	  "../grammars/kotlin/kotlin/KotlinLexer.g4",
+	  "../grammars/kotlin/kotlin/KotlinParser.g4",
+	  "../grammars/kotlin/kotlin/UnicodeClasses.g4"
+	],
+	"utilJavaFiles": [],
+	"startRule": "kotlinFile"
+  },
+  "processConfig": {
 		"splitConfig": {
 			"splitRules": ["statement"]
 		},
@@ -21,16 +23,16 @@
 				"RealLiteral": "N"
 			},
 			"indexedMapping": {
-              "//postfixUnaryExpression[../*[1]/.[@tag!='memberAccessOperator'] and ./*[2]/*/*[@tag!='valueArguments']]/*[1]/simpleIdentifier": "$V",
-              "//variableDeclaration/simpleIdentifier": "$V",
-              "//multiVariableDeclaration/simpleIdentifier": "$V"
-            },
+			  "//postfixUnaryExpression[../*[1]/.[@tag!='memberAccessOperator'] and ./*[2]/*/*[@tag!='valueArguments']]/*[1]/simpleIdentifier": "$V",
+			  "//variableDeclaration/simpleIdentifier": "$V",
+			  "//multiVariableDeclaration/simpleIdentifier": "$V"
+			},
 			"ignoreRules": [
-              "annotation",
-              "preamble",
-              "NL",
-              "EOF"
-            ]
+			  "annotation",
+			  "preamble",
+			  "NL",
+			  "EOF"
+			]
 		}
 	}
 }

--- a/config/lang/kotlin.json
+++ b/config/lang/kotlin.json
@@ -21,7 +21,9 @@
 				"RealLiteral": "N"
 			},
 			"indexedMapping": {
-              "//postfixUnaryExpression[../*[1]/.[@tag!='memberAccessOperator'] and ./*[2]/*/*[@tag!='valueArguments']]/*[1]/simpleIdentifier": "$V"
+              "//postfixUnaryExpression[../*[1]/.[@tag!='memberAccessOperator'] and ./*[2]/*/*[@tag!='valueArguments']]/*[1]/simpleIdentifier": "$V",
+              "//variableDeclaration/simpleIdentifier": "$V",
+              "//multiVariableDeclaration/simpleIdentifier": "$V"
             },
 			"ignoreRules": [
               "annotation",

--- a/src/main/kotlin/io/github/durun/nitron/core/ast/path/AstPath.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/ast/path/AstPath.kt
@@ -51,12 +51,12 @@ abstract class AstPath {
 
 private class AstXPath(expression: String) : AstPath() {
 	companion object {
-		private val xmlBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder()
-		private fun AstNode.toXml(): Node {
-			val str = this.accept(AstXmlBuildVisitor)
-			return xmlBuilder.parse(str.byteInputStream())
-		}
-	}
+        private val xmlBuilder = ThreadLocal.withInitial { DocumentBuilderFactory.newInstance().newDocumentBuilder() }
+        private fun AstNode.toXml(): Node {
+            val str = this.accept(AstXmlBuildVisitor)
+            return xmlBuilder.get().parse(str.byteInputStream())
+        }
+    }
 
 	private val xpath = DOMXPath(expression)
 


### PR DESCRIPTION
一部のidentifierが$Vへ正規化されないようになります。
- フィールドへのメンバアクセス
- メソッド名

## 解説
https://github.com/Durun/nitron/blob/18023855efd9681a1c1b33f9379b09453c4813a5/config/lang/kotlin.json#L25-L29

### ルール1
```json
"//postfixUnaryExpression[../*[1]/.[@tag!='memberAccessOperator'] and ./*[2]/*/*[@tag!='valueArguments']]/*[1]/simpleIdentifier": "$V"
```
expression中のidentifierを`$V`へ正規化します。
ただしメンバアクセスされたフィールドを除きます。(`value.member`の`member`は正規化しない)
また(`and`)メソッド名も除きます。(`method(arg)`の`method`は正規化しない)

### ルール2・3
```json
"//variableDeclaration/simpleIdentifier": "$V"
"//multiVariableDeclaration/simpleIdentifier": "$V" 
```
変数宣言を`$V`へ正規化します。
例:
- `val value: Int` → `val $V0: Int`
- `val (a,b) = method()` → `val ($V0, $V1) = method()`
- `run { i -> i.toString() }` → `run { $V0 -> $V0.toString() }`