### PR TITLE
C#用の新しい抽出ルール

### DIFF
--- a/config/lang/csharp.json
+++ b/config/lang/csharp.json
@@ -29,10 +29,10 @@
 				"REAL_LITERAL": "N"
 			},
 			"indexedMapping": {
-				"primary_expression_start/identifier": "$V",
-				"variable_declarator/identifier": "$V",
-				"local_variable_declarator/identifier": "$V",
-				"constant_declarator/identifier": "$V"
+			  "//primary_expression[./*[2]/.[@tag!='method_invocation'] or count(./*)=1]/primary_expression_start/identifier": "$V",
+			  "//variable_declarator/identifier": "$V",
+			  "//local_variable_declarator/identifier": "$V",
+			  "//constant_declarator/identifier": "$V"
 			},
 			"ignoreRules": [
 				"global_attribute_section",


### PR DESCRIPTION
一部のidentifierが$Vへ正規化されないようになります。
- メソッド名

## 解説
https://github.com/Durun/nitron/blob/8534427790339786f1db83b2f6dd3524e39b8dc3/config/lang/csharp.json#L31-L36

### ルール1
```json
"//primary_expression[./*[2]/.[@tag!='method_invocation'] or count(./*)=1]/primary_expression_start/identifier": "$V", 
```
expression中のidentifierを`$V`へ正規化します。
ただし、メソッド名は除きます。

### ルール2
```json
"//variable_declarator/identifier": "$V", 
```
### ルール3
```json
"//local_variable_declarator/identifier": "$V", 
```
### ルール4
```json
"//constant_declarator/identifier": "$V" 
```