### PR TITLE
C++用の抽出ルール

### DIFF
--- a/config/lang/cpp.json
+++ b/config/lang/cpp.json
@@ -1,0 +1,44 @@
+{
+  "extensions": [
+	".h",
+	".hpp",
+	".c",
+	".cpp"
+  ],
+  "grammarConfig": {
+	"grammarFiles": [
+	  "../grammars/cpp/CPP14Lexer.g4",
+	  "../grammars/cpp/CPP14Parser.g4"
+	],
+	"utilJavaFiles": [],
+	"startRule": "translationUnit"
+  },
+  "processConfig": {
+	"splitConfig": {
+	  "splitRules": [
+		"statement"
+	  ]
+	},
+	"normalizeConfig": {
+	  "mapping": {
+		"Literal": "L"
+	  },
+	  "indexedMapping": {
+		"//declarator[..[@tag!='functionDefinition']]/*/*/*/*/*/Identifier": "$V",
+		"//className/Identifier": "$V",
+		"//postfixExpression[../*[2]/.[@tag='Dot' or @tag='Arrow']]/primaryExpression/idExpression/unqualifiedId": "$V",
+		"//postfixExpression[../*[2]/.[@tag!='LeftParen'] or count(../*)=1]/primaryExpression/idExpression/unqualifiedId": "$V"
+	  },
+	  "ignoreRules": [
+		"usingDirective",
+		"Const",
+		"Constexpr",
+		"Friend",
+		"storageClassSpecifier",
+		"functionSpecifier",
+		"accessSpecifier",
+		"EOF"
+	  ]
+	}
+  }
+}

--- a/config/nitron.json
+++ b/config/nitron.json
@@ -1,13 +1,14 @@
 {
     "langConfigFiles": {
-      "java": "lang/java.json",
-      "kotlin": "lang/kotlin.json",
-      "python": "lang/python.json",
-      "csharp": "lang/csharp.json",
-      "r": "lang/r.json",
-      "javascript": "lang/javascript.json",
-      "swift": "lang/swift3.json",
-      "matlab": "lang/matlab.json",
-      "erlang": "lang/erlang.json"
-    }
+	  "java": "lang/java.json",
+	  "kotlin": "lang/kotlin.json",
+	  "python": "lang/python.json",
+	  "cpp": "lang/cpp.json",
+	  "csharp": "lang/csharp.json",
+	  "r": "lang/r.json",
+	  "javascript": "lang/javascript.json",
+	  "swift": "lang/swift3.json",
+	  "matlab": "lang/matlab.json",
+	  "erlang": "lang/erlang.json"
+	}
 }


### PR DESCRIPTION
## 解説
https://github.com/Durun/nitron/blob/8fd5a2394fd778083f0617a2f72ca95ee91ae91f/config/lang/cpp.json#L26-L31

### ルール1
```json
"//declarator[..[@tag!='functionDefinition']]/*/*/*/*/*/Identifier": "$V", 
```
変数宣言の変数名を`$V`へ正規化する(関数名は除く)
`int a,b;` → `int $V0, $V1;`

### ルール2
```json
"//className/Identifier": "$V", 
```
変数宣言の変数名を`$V`へ正規化する
`int a;` → `int $V0;`

### ルール3
```json
"//postfixExpression[../*[2]/.[@tag='Dot' or @tag='Arrow']]/primaryExpression/idExpression/unqualifiedId": "$V", 
```
メンバアクセスの最初の要素を正規化する
`var.member;` → `$V0.member;`
`var->func();` → `$V0->func();`

### ルール4
```json
"//postfixExpression[../*[2]/.[@tag!='LeftParen'] or count(../*)=1]/primaryExpression/idExpression/unqualifiedId": "$V" 
```
変数名を正規化する(関数呼び出しは除く)
`func(a);` → `func($V0);`