### PR TITLE
設定ファイルでパーサのタイプを指定可能に

### DIFF
--- a/config/lang/cpp.json
+++ b/config/lang/cpp.json
@@ -6,6 +6,7 @@
 	".cpp"
   ],
   "grammarConfig": {
+	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/cpp/CPP14Lexer.g4",
 	  "../grammars/cpp/CPP14Parser.g4"

--- a/config/lang/cpp.json
+++ b/config/lang/cpp.json
@@ -5,7 +5,7 @@
 	".c",
 	".cpp"
   ],
-  "grammarConfig": {
+  "parser": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/cpp/CPP14Lexer.g4",

--- a/config/lang/cpp.json
+++ b/config/lang/cpp.json
@@ -5,7 +5,7 @@
 	".c",
 	".cpp"
   ],
-  "parser": {
+  "parserConfig": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/cpp/CPP14Lexer.g4",

--- a/config/lang/csharp.json
+++ b/config/lang/csharp.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".cs"],
-	"grammarConfig": {
+	"parser": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/csharp/CSharpLexer.g4",

--- a/config/lang/csharp.json
+++ b/config/lang/csharp.json
@@ -1,13 +1,14 @@
 {
     "extensions": [".cs"],
 	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/csharp/CSharpLexer.g4",
-			"../grammars/csharp/CSharpParser.g4",
-			"../grammars/csharp/CSharpPreprocessorParser.g4"
-		],
-		"utilJavaFiles": [],
-		"startRule": "compilation_unit"
+	  "type": "antlr",
+	  "grammarFiles": [
+		"../grammars/csharp/CSharpLexer.g4",
+		"../grammars/csharp/CSharpParser.g4",
+		"../grammars/csharp/CSharpPreprocessorParser.g4"
+	  ],
+	  "utilJavaFiles": [],
+	  "startRule": "compilation_unit"
 	},
 	"processConfig": {
 		"splitConfig": {

--- a/config/lang/csharp.json
+++ b/config/lang/csharp.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".cs"],
-	"parser": {
+	"parserConfig": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/csharp/CSharpLexer.g4",

--- a/config/lang/erlang.json
+++ b/config/lang/erlang.json
@@ -1,11 +1,12 @@
 {
     "extensions": [".erl"],
 	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/erlang/Erlang.g4"
-		],
-		"utilJavaFiles": [],
-		"startRule": "forms"
+	  "type": "antlr",
+	  "grammarFiles": [
+		"../grammars/erlang/Erlang.g4"
+	  ],
+	  "utilJavaFiles": [],
+	  "startRule": "forms"
 	},
 	"processConfig": {
 		"splitConfig": {

--- a/config/lang/erlang.json
+++ b/config/lang/erlang.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".erl"],
-	"parser": {
+	"parserConfig": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/erlang/Erlang.g4"

--- a/config/lang/erlang.json
+++ b/config/lang/erlang.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".erl"],
-	"grammarConfig": {
+	"parser": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/erlang/Erlang.g4"

--- a/config/lang/java.json
+++ b/config/lang/java.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".java"],
-	"parser": {
+	"parserConfig": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/java/java8/Java8Lexer.g4",

--- a/config/lang/java.json
+++ b/config/lang/java.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".java"],
-	"grammarConfig": {
+	"parser": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/java/java8/Java8Lexer.g4",

--- a/config/lang/java.json
+++ b/config/lang/java.json
@@ -1,12 +1,13 @@
 {
     "extensions": [".java"],
 	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/java/java8/Java8Lexer.g4",
-			"../grammars/java/java8/Java8Parser.g4"
-		],
-		"utilJavaFiles": [],
-		"startRule": "compilationUnit"
+	  "type": "antlr",
+	  "grammarFiles": [
+		"../grammars/java/java8/Java8Lexer.g4",
+		"../grammars/java/java8/Java8Parser.g4"
+	  ],
+	  "utilJavaFiles": [],
+	  "startRule": "compilationUnit"
 	},
 	"processConfig": {
 		"splitConfig": {

--- a/config/lang/javascript.json
+++ b/config/lang/javascript.json
@@ -1,15 +1,16 @@
 {
   "extensions": [".js"],
   "grammarConfig": {
-    "grammarFiles": [
-      "../grammars/javascript/javascript/JavaScriptParser.g4",
-      "../grammars/javascript/javascript/JavaScriptLexer.g4"
-    ],
-    "utilJavaFiles": [
-      "../grammars/javascript/javascript/Java/JavaScriptParserBase.java",
-      "../grammars/javascript/javascript/Java/JavaScriptLexerBase.java"
-    ],
-    "startRule": "program"
+	"type": "antlr",
+	"grammarFiles": [
+	  "../grammars/javascript/javascript/JavaScriptParser.g4",
+	  "../grammars/javascript/javascript/JavaScriptLexer.g4"
+	],
+	"utilJavaFiles": [
+	  "../grammars/javascript/javascript/Java/JavaScriptParserBase.java",
+	  "../grammars/javascript/javascript/Java/JavaScriptLexerBase.java"
+	],
+	"startRule": "program"
   },
   "processConfig": {
     "splitConfig": {

--- a/config/lang/javascript.json
+++ b/config/lang/javascript.json
@@ -1,6 +1,6 @@
 {
   "extensions": [".js"],
-  "parser": {
+  "parserConfig": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/javascript/javascript/JavaScriptParser.g4",

--- a/config/lang/javascript.json
+++ b/config/lang/javascript.json
@@ -1,6 +1,6 @@
 {
   "extensions": [".js"],
-  "grammarConfig": {
+  "parser": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/javascript/javascript/JavaScriptParser.g4",

--- a/config/lang/kotlin.json
+++ b/config/lang/kotlin.json
@@ -3,6 +3,7 @@
 	".kt"
   ],
   "grammarConfig": {
+	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/kotlin/kotlin/KotlinLexer.g4",
 	  "../grammars/kotlin/kotlin/KotlinParser.g4",

--- a/config/lang/kotlin.json
+++ b/config/lang/kotlin.json
@@ -2,7 +2,7 @@
   "extensions": [
 	".kt"
   ],
-  "grammarConfig": {
+  "parser": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/kotlin/kotlin/KotlinLexer.g4",

--- a/config/lang/kotlin.json
+++ b/config/lang/kotlin.json
@@ -2,7 +2,7 @@
   "extensions": [
 	".kt"
   ],
-  "parser": {
+  "parserConfig": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/kotlin/kotlin/KotlinLexer.g4",

--- a/config/lang/matlab.json
+++ b/config/lang/matlab.json
@@ -1,11 +1,12 @@
 {
     "extensions": [".m"],
 	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/matlab/matlab.g4"
-		],
-		"utilJavaFiles": [],
-		"startRule": "translation_unit"
+	  "type": "antlr",
+	  "grammarFiles": [
+		"../grammars/matlab/matlab.g4"
+	  ],
+	  "utilJavaFiles": [],
+	  "startRule": "translation_unit"
 	},
 	"processConfig": {
 		"splitConfig": {

--- a/config/lang/matlab.json
+++ b/config/lang/matlab.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".m"],
-	"grammarConfig": {
+	"parser": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/matlab/matlab.g4"

--- a/config/lang/matlab.json
+++ b/config/lang/matlab.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".m"],
-	"parser": {
+	"parserConfig": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/matlab/matlab.g4"

--- a/config/lang/python.json
+++ b/config/lang/python.json
@@ -1,6 +1,6 @@
 {
 	"extensions": [".py"],
-	"parser": {
+	"parserConfig": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/python/python3/Python3.g4"

--- a/config/lang/python.json
+++ b/config/lang/python.json
@@ -1,11 +1,12 @@
 {
 	"extensions": [".py"],
 	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/python/python3/Python3.g4"
-		],
-		"utilJavaFiles": [],
-		"startRule": "file_input"
+	  "type": "antlr",
+	  "grammarFiles": [
+		"../grammars/python/python3/Python3.g4"
+	  ],
+	  "utilJavaFiles": [],
+	  "startRule": "file_input"
 	},
 	"processConfig": {
 		"splitConfig": {

--- a/config/lang/python.json
+++ b/config/lang/python.json
@@ -1,6 +1,6 @@
 {
 	"extensions": [".py"],
-	"grammarConfig": {
+	"parser": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/python/python3/Python3.g4"

--- a/config/lang/r.json
+++ b/config/lang/r.json
@@ -1,11 +1,12 @@
 {
   "extensions": [".r"],
   "grammarConfig": {
-    "grammarFiles": [
-      "../grammars/r/R.g4"
-    ],
-    "utilJavaFiles": [],
-    "startRule": "prog"
+	"type": "antlr",
+	"grammarFiles": [
+	  "../grammars/r/R.g4"
+	],
+	"utilJavaFiles": [],
+	"startRule": "prog"
   },
   "processConfig": {
     "splitConfig": {

--- a/config/lang/r.json
+++ b/config/lang/r.json
@@ -1,6 +1,6 @@
 {
   "extensions": [".r"],
-  "parser": {
+  "parserConfig": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/r/R.g4"

--- a/config/lang/r.json
+++ b/config/lang/r.json
@@ -1,6 +1,6 @@
 {
   "extensions": [".r"],
-  "grammarConfig": {
+  "parser": {
 	"type": "antlr",
 	"grammarFiles": [
 	  "../grammars/r/R.g4"

--- a/config/lang/swift3.json
+++ b/config/lang/swift3.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".swift"],
-	"parser": {
+	"parserConfig": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/swift/swift3/Swift3.g4"

--- a/config/lang/swift3.json
+++ b/config/lang/swift3.json
@@ -1,6 +1,6 @@
 {
     "extensions": [".swift"],
-	"grammarConfig": {
+	"parser": {
 	  "type": "antlr",
 	  "grammarFiles": [
 		"../grammars/swift/swift3/Swift3.g4"

--- a/config/lang/swift3.json
+++ b/config/lang/swift3.json
@@ -1,13 +1,14 @@
 {
     "extensions": [".swift"],
 	"grammarConfig": {
-		"grammarFiles": [
-			"../grammars/swift/swift3/Swift3.g4"
-		],
-		"utilJavaFiles": [
-			"../grammars/swift/swift3/src/main/java/SwiftSupport.java"
-		],
-		"startRule": "top_level"
+	  "type": "antlr",
+	  "grammarFiles": [
+		"../grammars/swift/swift3/Swift3.g4"
+	  ],
+	  "utilJavaFiles": [
+		"../grammars/swift/swift3/src/main/java/SwiftSupport.java"
+	  ],
+	  "startRule": "top_level"
 	},
 	"processConfig": {
 		"splitConfig": {

--- a/src/main/kotlin/io/github/durun/nitron/app/AstPrintCommand.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/AstPrintCommand.kt
@@ -46,7 +46,7 @@ class AstPrintCommand : CliktCommand(
     @ExperimentalPathApi
     override fun run() {
         val config = LangConfigLoader.load(configPath)
-        val astBuilder = config.grammar.getParser()
+        val astBuilder = config.parserConfig.getParser()
         inputs
             .forEach { input ->
                 val ast = astBuilder.parse(input.bufferedReader())

--- a/src/main/kotlin/io/github/durun/nitron/app/AstPrintCommand.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/AstPrintCommand.kt
@@ -9,8 +9,6 @@ import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.path
 import io.github.durun.nitron.core.ast.visitor.AstPrintVisitor
 import io.github.durun.nitron.core.config.loader.LangConfigLoader
-import io.github.durun.nitron.core.parser.AstBuilders
-import io.github.durun.nitron.core.parser.antlr.antlr
 import java.io.BufferedWriter
 import java.io.File
 import java.nio.file.Path
@@ -48,12 +46,7 @@ class AstPrintCommand : CliktCommand(
     @ExperimentalPathApi
     override fun run() {
         val config = LangConfigLoader.load(configPath)
-        val astBuilder = AstBuilders.antlr(
-            grammarName = config.fileName,
-            entryPoint = config.grammar.startRule,
-            grammarFiles = config.grammar.grammarFilePaths,
-            utilityJavaFiles = config.grammar.utilJavaFilePaths
-        )
+        val astBuilder = config.grammar.getParser()
         inputs
             .forEach { input ->
                 val ast = astBuilder.parse(input.bufferedReader())

--- a/src/main/kotlin/io/github/durun/nitron/app/preparse/DbUtil.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/preparse/DbUtil.kt
@@ -14,7 +14,6 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.lessEq
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import java.net.URL
-import kotlin.io.path.readText
 
 internal class DbUtil(
     val db: Database
@@ -76,11 +75,7 @@ internal class DbUtil(
 
     @kotlin.io.path.ExperimentalPathApi
     fun isLanguageConsistent(langName: String, langConfig: LangConfig): Boolean {
-        val paths = langConfig.grammar.grammarFilePaths + langConfig.grammar.utilJavaFilePaths
-        val checksum = paths.map { MD5.digest(it.readText()).toString() }
-            .sorted()
-            .reduce { a, b -> a + b }
-            .let { MD5.digest(it) }
+        val checksum = langConfig.grammar.checksum()
 
         val correctSum = transaction(db) {
             val rows = LanguageTable.select { LanguageTable.name eq langName }

--- a/src/main/kotlin/io/github/durun/nitron/app/preparse/DbUtil.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/preparse/DbUtil.kt
@@ -75,7 +75,7 @@ internal class DbUtil(
 
     @kotlin.io.path.ExperimentalPathApi
     fun isLanguageConsistent(langName: String, langConfig: LangConfig): Boolean {
-        val checksum = langConfig.grammar.checksum()
+        val checksum = langConfig.parserConfig.checksum()
 
         val correctSum = transaction(db) {
             val rows = LanguageTable.select { LanguageTable.name eq langName }

--- a/src/main/kotlin/io/github/durun/nitron/app/preparse/ParseUtil.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/preparse/ParseUtil.kt
@@ -19,7 +19,7 @@ class ParseUtil(
 
     fun parseText(text: String, langName: String, langConfig: LangConfig): String {
         val astBuilder = synchronized(astBuilders) {
-            astBuilders.computeIfAbsent(langName) { langConfig.grammar.getParser() }
+            astBuilders.computeIfAbsent(langName) { langConfig.parserConfig.getParser() }
         }
         val ast = astBuilder.parse(text.reader())
         return encoder.encodeToString(ast)

--- a/src/main/kotlin/io/github/durun/nitron/app/preparse/ParseUtil.kt
+++ b/src/main/kotlin/io/github/durun/nitron/app/preparse/ParseUtil.kt
@@ -4,8 +4,6 @@ import io.github.durun.nitron.core.AstSerializers
 import io.github.durun.nitron.core.config.LangConfig
 import io.github.durun.nitron.core.config.NitronConfig
 import io.github.durun.nitron.core.parser.AstBuilder
-import io.github.durun.nitron.core.parser.AstBuilders
-import io.github.durun.nitron.core.parser.antlr.antlr
 import kotlinx.serialization.encodeToString
 import java.io.ByteArrayOutputStream
 import java.util.zip.Deflater
@@ -21,14 +19,7 @@ class ParseUtil(
 
     fun parseText(text: String, langName: String, langConfig: LangConfig): String {
         val astBuilder = synchronized(astBuilders) {
-            astBuilders.computeIfAbsent(langName) {
-                AstBuilders.antlr(
-                    grammarName = langConfig.fileName,
-                    entryPoint = langConfig.grammar.startRule,
-                    grammarFiles = langConfig.grammar.grammarFilePaths,
-                    utilityJavaFiles = langConfig.grammar.utilJavaFilePaths
-                )
-            }
+            astBuilders.computeIfAbsent(langName) { langConfig.grammar.getParser() }
         }
         val ast = astBuilder.parse(text.reader())
         return encoder.encodeToString(ast)

--- a/src/main/kotlin/io/github/durun/nitron/binding/cpanalyzer/CodeProcessor.kt
+++ b/src/main/kotlin/io/github/durun/nitron/binding/cpanalyzer/CodeProcessor.kt
@@ -19,17 +19,17 @@ class CodeProcessor(
     private val astBuilder: AstBuilder = config.parserConfig.getParser()
     val nodeTypePool: NodeTypePool = astBuilder.nodeTypes
     private val splitter = ThreadLocal.withInitial {
-        AstSplitter(config.process.splitConfig.splitRules.mapNotNull { nodeTypePool.getType(it) })
+        AstSplitter(config.processConfig.splitConfig.splitRules.mapNotNull { nodeTypePool.getType(it) })
     }
     private val normalizer = ThreadLocal.withInitial {
         AstNormalizer(
-            mapping = config.process.normalizeConfig.mapping.entries.associate { (path, symbol) ->
+            mapping = config.processConfig.normalizeConfig.mapping.entries.associate { (path, symbol) ->
                 AstPath.of(path, nodeTypePool) to symbol
             },
-            numberedMapping = config.process.normalizeConfig.indexedMapping.entries.associate { (path, symbol) ->
+            numberedMapping = config.processConfig.normalizeConfig.indexedMapping.entries.associate { (path, symbol) ->
                 AstPath.of(path, nodeTypePool) to symbol
             },
-            ignoreRules = config.process.normalizeConfig.ignoreRules.map {
+            ignoreRules = config.processConfig.normalizeConfig.ignoreRules.map {
                 AstPath.of(it, nodeTypePool)
             }
         )

--- a/src/main/kotlin/io/github/durun/nitron/binding/cpanalyzer/CodeProcessor.kt
+++ b/src/main/kotlin/io/github/durun/nitron/binding/cpanalyzer/CodeProcessor.kt
@@ -16,7 +16,7 @@ class CodeProcessor(
     config: LangConfig,
     outputPath: Path? = null    // TODO recording feature should be separated
 ) {
-    private val astBuilder: AstBuilder = config.grammar.getParser()
+    private val astBuilder: AstBuilder = config.parserConfig.getParser()
     val nodeTypePool: NodeTypePool = astBuilder.nodeTypes
     private val splitter = ThreadLocal.withInitial {
         AstSplitter(config.process.splitConfig.splitRules.mapNotNull { nodeTypePool.getType(it) })

--- a/src/main/kotlin/io/github/durun/nitron/binding/cpanalyzer/CodeProcessor.kt
+++ b/src/main/kotlin/io/github/durun/nitron/binding/cpanalyzer/CodeProcessor.kt
@@ -7,8 +7,6 @@ import io.github.durun.nitron.core.ast.processors.AstSplitter
 import io.github.durun.nitron.core.ast.type.NodeTypePool
 import io.github.durun.nitron.core.config.LangConfig
 import io.github.durun.nitron.core.parser.AstBuilder
-import io.github.durun.nitron.core.parser.AstBuilders
-import io.github.durun.nitron.core.parser.antlr.antlr
 import io.github.durun.nitron.inout.model.ast.Structure
 import io.github.durun.nitron.inout.model.ast.merge
 import io.github.durun.nitron.inout.model.ast.table.StructuresJsonWriter
@@ -18,13 +16,7 @@ class CodeProcessor(
     config: LangConfig,
     outputPath: Path? = null    // TODO recording feature should be separated
 ) {
-    private val startRule: String = config.grammar.startRule
-    private val astBuilder: AstBuilder = AstBuilders.antlr(
-        grammarName = config.fileName,
-        entryPoint = startRule,
-        grammarFiles = config.grammar.grammarFilePaths,
-        utilityJavaFiles = config.grammar.utilJavaFilePaths
-    )
+    private val astBuilder: AstBuilder = config.grammar.getParser()
     val nodeTypePool: NodeTypePool = astBuilder.nodeTypes
     private val splitter = ThreadLocal.withInitial {
         AstSplitter(config.process.splitConfig.splitRules.mapNotNull { nodeTypePool.getType(it) })

--- a/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
@@ -46,20 +46,6 @@ data class LangConfig(
 }
 
 @Serializable
-data class GrammarConfig(
-        private val grammarFiles: List<String>,
-        private val utilJavaFiles: List<String>,
-        val startRule: String
-) : ConfigWithDir() {
-    val grammarFilePaths: List<Path> by lazy {
-        grammarFiles.map { dir.resolve(it) }
-    }
-    val utilJavaFilePaths: List<Path> by lazy {
-        utilJavaFiles.map { dir.resolve(it) }
-    }
-}
-
-@Serializable
 data class ProcessConfig(
         val splitConfig: SplitConfig,
         val normalizeConfig: NormalizeConfig

--- a/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
@@ -36,11 +36,11 @@ data class NitronConfig(
 
 @Serializable
 data class LangConfig(
-        private val grammarConfig: GrammarConfig,
-        private val processConfig: ProcessConfig,
-        val extensions: List<String>
+    private val grammarConfig: ParserConfig,
+    private val processConfig: ProcessConfig,
+    val extensions: List<String>
 ) : ConfigWithDir() {
-    val grammar: GrammarConfig by lazy { grammarConfig.setPath(path) }
+    val grammar: ParserConfig by lazy { grammarConfig.setPath(path) }
     val process: ProcessConfig
         get() = processConfig
 }

--- a/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
@@ -40,7 +40,7 @@ data class LangConfig(
     private val processConfig: ProcessConfig,
     val extensions: List<String>
 ) : ConfigWithDir() {
-    val grammar: ParserConfig by lazy { parser.setPath(path) }
+    val parserConfig: ParserConfig by lazy { parser.setPath(path) }
     val process: ProcessConfig
         get() = processConfig
 }

--- a/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
@@ -37,12 +37,10 @@ data class NitronConfig(
 @Serializable
 data class LangConfig(
     private val parser: ParserConfig,
-    private val processConfig: ProcessConfig,
+    val processConfig: ProcessConfig,
     val extensions: List<String>
 ) : ConfigWithDir() {
     val parserConfig: ParserConfig by lazy { parser.setPath(path) }
-    val process: ProcessConfig
-        get() = processConfig
 }
 
 @Serializable

--- a/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
@@ -36,11 +36,11 @@ data class NitronConfig(
 
 @Serializable
 data class LangConfig(
-    private val grammarConfig: ParserConfig,
+    private val parser: ParserConfig,
     private val processConfig: ProcessConfig,
     val extensions: List<String>
 ) : ConfigWithDir() {
-    val grammar: ParserConfig by lazy { grammarConfig.setPath(path) }
+    val grammar: ParserConfig by lazy { parser.setPath(path) }
     val process: ProcessConfig
         get() = processConfig
 }

--- a/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/NitronConfig.kt
@@ -1,6 +1,7 @@
 package io.github.durun.nitron.core.config
 
 import io.github.durun.nitron.core.config.loader.LangConfigLoader
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.nio.file.Path
 
@@ -36,7 +37,7 @@ data class NitronConfig(
 
 @Serializable
 data class LangConfig(
-    private val parser: ParserConfig,
+    @SerialName("parserConfig") private val parser: ParserConfig,
     val processConfig: ProcessConfig,
     val extensions: List<String>
 ) : ConfigWithDir() {

--- a/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
@@ -10,7 +10,7 @@ import java.nio.file.Path
 
 
 @Serializable
-sealed class GrammarConfig : ConfigWithDir() {
+sealed class ParserConfig : ConfigWithDir() {
     abstract fun getParser(): AstBuilder
     abstract fun checksum(): MD5
 }
@@ -21,7 +21,7 @@ data class AntlrParserConfig(
     private val grammarFiles: List<String>,
     private val utilJavaFiles: List<String>,
     val startRule: String
-) : GrammarConfig() {
+) : ParserConfig() {
     val grammarFilePaths: List<Path> by lazy {
         grammarFiles.map { dir.resolve(it) }
     }

--- a/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
@@ -1,0 +1,70 @@
+package io.github.durun.nitron.core.config
+
+import io.github.durun.nitron.core.MD5
+import io.github.durun.nitron.core.parser.AstBuilder
+import io.github.durun.nitron.core.parser.AstBuilders
+import io.github.durun.nitron.core.parser.antlr.antlr
+import kotlinx.serialization.Serializable
+import java.nio.file.Path
+
+
+@Serializable
+sealed class GrammarConfig(
+    private val grammarFiles: List<String>,
+    private val utilJavaFiles: List<String>,
+    val startRule: String
+) : ConfigWithDir() {
+    val grammarFilePaths: List<Path> by lazy {
+        grammarFiles.map { dir.resolve(it) }
+    }
+    val utilJavaFilePaths: List<Path> by lazy {
+        utilJavaFiles.map { dir.resolve(it) }
+    }
+
+    fun getParser(): AstBuilder = AstBuilders.antlr(
+        grammarName = fileName,
+        entryPoint = startRule,
+        grammarFiles = grammarFilePaths,
+        utilityJavaFiles = utilJavaFilePaths
+    )
+
+    fun checksum(): MD5 {
+        val paths = grammarFilePaths + utilJavaFilePaths
+        return paths.map { MD5.digest(it.toFile().readText()).toString() }
+            .sorted()
+            .reduce { a, b -> a + b }
+            .let { MD5.digest(it) }
+    }
+}
+/*
+
+@Serializable
+@SerialName("antlr")
+data class AntlrParserConfig(
+    private val grammarFiles: List<String>,
+    private val utilJavaFiles: List<String>,
+    val startRule: String
+) : GrammarConfig() {
+    val grammarFilePaths: List<Path> by lazy {
+        grammarFiles.map { dir.resolve(it) }
+    }
+    val utilJavaFilePaths: List<Path> by lazy {
+        utilJavaFiles.map { dir.resolve(it) }
+    }
+
+    override fun getParser(): AstBuilder = AstBuilders.antlr(
+        grammarName = fileName,
+        entryPoint = startRule,
+        grammarFiles = grammarFilePaths,
+        utilityJavaFiles = utilJavaFilePaths
+    )
+
+    override fun checksum(): MD5 {
+        val paths = grammarFilePaths + utilJavaFilePaths
+        return paths.map { MD5.digest(it.toFile().readText()).toString() }
+            .sorted()
+            .reduce { a, b -> a + b }
+            .let { MD5.digest(it) }
+    }
+}
+*/

--- a/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
@@ -4,39 +4,16 @@ import io.github.durun.nitron.core.MD5
 import io.github.durun.nitron.core.parser.AstBuilder
 import io.github.durun.nitron.core.parser.AstBuilders
 import io.github.durun.nitron.core.parser.antlr.antlr
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.nio.file.Path
 
 
 @Serializable
-sealed class GrammarConfig(
-    private val grammarFiles: List<String>,
-    private val utilJavaFiles: List<String>,
-    val startRule: String
-) : ConfigWithDir() {
-    val grammarFilePaths: List<Path> by lazy {
-        grammarFiles.map { dir.resolve(it) }
-    }
-    val utilJavaFilePaths: List<Path> by lazy {
-        utilJavaFiles.map { dir.resolve(it) }
-    }
-
-    fun getParser(): AstBuilder = AstBuilders.antlr(
-        grammarName = fileName,
-        entryPoint = startRule,
-        grammarFiles = grammarFilePaths,
-        utilityJavaFiles = utilJavaFilePaths
-    )
-
-    fun checksum(): MD5 {
-        val paths = grammarFilePaths + utilJavaFilePaths
-        return paths.map { MD5.digest(it.toFile().readText()).toString() }
-            .sorted()
-            .reduce { a, b -> a + b }
-            .let { MD5.digest(it) }
-    }
+sealed class GrammarConfig : ConfigWithDir() {
+    abstract fun getParser(): AstBuilder
+    abstract fun checksum(): MD5
 }
-/*
 
 @Serializable
 @SerialName("antlr")
@@ -67,4 +44,3 @@ data class AntlrParserConfig(
             .let { MD5.digest(it) }
     }
 }
-*/

--- a/src/main/kotlin/io/github/durun/nitron/core/config/loader/KSerializationConfigLoader.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/loader/KSerializationConfigLoader.kt
@@ -9,12 +9,14 @@ import java.nio.file.Path
 class KSerializationConfigLoader<C : ConfigWithDir>(
         private val serializer: KSerializer<C>
 ) : ConfigLoader<C> {
+    val json = Json {
+        ignoreUnknownKeys = true
+        classDiscriminator = "type"
+    }
+
     override fun load(jsonFile: Path): C {
-        val json = jsonFile
-                .toFile()
-                .bufferedReader()
-                .readText()
-        val config = Json.decodeFromString(serializer, json)
+        val jsonString = jsonFile.toFile().readText()
+        val config = json.decodeFromString(serializer, jsonString)
         return config.setPath(jsonFile)
     }
 }

--- a/src/main/kotlin/io/github/durun/nitron/inout/model/preparse/LanguageTable.kt
+++ b/src/main/kotlin/io/github/durun/nitron/inout/model/preparse/LanguageTable.kt
@@ -1,12 +1,10 @@
 package io.github.durun.nitron.inout.model.preparse
 
-import io.github.durun.nitron.core.MD5
 import io.github.durun.nitron.core.config.LangConfig
 import org.jetbrains.exposed.dao.EntityID
 import org.jetbrains.exposed.dao.IntIdTable
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.insertAndGetId
-import kotlin.io.path.readText
 
 object LanguageTable : IntIdTable("languages") {
     val name: Column<String> = text("name")
@@ -17,12 +15,7 @@ object LanguageTable : IntIdTable("languages") {
 @kotlin.io.path.ExperimentalPathApi
 fun LanguageTable.insertAndGetId(langName: String, langConfig: LangConfig): EntityID<Int> {
     return insertAndGetId {
-        val grammars = langConfig.grammar.grammarFilePaths + langConfig.grammar.utilJavaFilePaths
         it[this.name] = langName
-        it[this.checksum] = grammars.map { MD5.digest(it.readText()).toString() }
-            .sorted()
-            .reduce { a, b -> a + b }
-            .let { MD5.digest(it) }
-            .toString()
+        it[this.checksum] = langConfig.grammar.checksum().toString()
     }
 }

--- a/src/main/kotlin/io/github/durun/nitron/inout/model/preparse/LanguageTable.kt
+++ b/src/main/kotlin/io/github/durun/nitron/inout/model/preparse/LanguageTable.kt
@@ -16,6 +16,6 @@ object LanguageTable : IntIdTable("languages") {
 fun LanguageTable.insertAndGetId(langName: String, langConfig: LangConfig): EntityID<Int> {
     return insertAndGetId {
         it[this.name] = langName
-        it[this.checksum] = langConfig.grammar.checksum().toString()
+        it[this.checksum] = langConfig.parserConfig.checksum().toString()
     }
 }

--- a/src/test/kotlin/io/github/durun/nitron/app/preparse/ExtractorTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/app/preparse/ExtractorTest.kt
@@ -2,9 +2,6 @@ package io.github.durun.nitron.app.preparse
 
 import io.github.durun.nitron.core.MD5
 import io.github.durun.nitron.core.config.loader.NitronConfigLoader
-import io.github.durun.nitron.core.parser.antlr.AstBuildVisitor
-import io.github.durun.nitron.core.parser.antlr.ParserStore
-import io.github.durun.nitron.core.parser.antlr.nodeTypePoolOf
 import io.github.durun.nitron.inout.database.MemoryDatabase
 import io.github.durun.nitron.inout.model.preparse.*
 import io.kotest.core.spec.style.FreeSpec
@@ -17,14 +14,12 @@ import java.net.URL
 import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
 
-@OptIn(ExperimentalPathApi::class)
+@ExperimentalPathApi
 class ExtractorTest : FreeSpec({
     "test" {
-        val tree = parser.parse(testCode.reader(), javaConfig.startRule)
-        val ast = tree.accept(converter)
+        val ast = parser.parse(testCode.reader())
         println(ast)
-
-        val types = nodeTypePoolOf("java", parser.antlrParser)
+        val types = parser.nodeTypes
         val parseUtil = ParseUtil(config)
         val repoUrl = URL("https://github.com/example/testProject.git")
         val commitHash = "1234abcd1234abcd1234abcd1234abcd1234abcd"
@@ -86,9 +81,7 @@ class ExtractorTest : FreeSpec({
 })
 
 private val config = NitronConfigLoader.load(Path.of("config/nitron.json"))
-private val javaConfig = config.langConfig["java"]!!.grammar
-private val parser = ParserStore.getOrThrow(javaConfig)
-private val converter = AstBuildVisitor(parser.antlrParser.grammarFileName, parser.antlrParser)
+private val parser = config.langConfig["java"]!!.grammar.getParser()
 private val testCode = """
     class Sample {
         public static void main(String[] args){

--- a/src/test/kotlin/io/github/durun/nitron/app/preparse/ExtractorTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/app/preparse/ExtractorTest.kt
@@ -81,7 +81,7 @@ class ExtractorTest : FreeSpec({
 })
 
 private val config = NitronConfigLoader.load(Path.of("config/nitron.json"))
-private val parser = config.langConfig["java"]!!.grammar.getParser()
+private val parser = config.langConfig["java"]!!.parserConfig.getParser()
 private val testCode = """
     class Sample {
         public static void main(String[] args){

--- a/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstNormalizerTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstNormalizerTest.kt
@@ -8,7 +8,7 @@ import java.nio.file.Paths
 
 class AstNormalizerTest : FreeSpec({
 	val config = LangConfigLoader.load(Paths.get("config/lang/java.json"))
-    val parser = config.grammar.getParser()
+    val parser = config.parserConfig.getParser()
     val javaAst = parser.parse(javaCode.reader())
     val types = parser.nodeTypes
 

--- a/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstNormalizerTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstNormalizerTest.kt
@@ -2,44 +2,40 @@ package io.github.durun.nitron.core.ast.processors
 
 import io.github.durun.nitron.core.ast.path.AstPath
 import io.github.durun.nitron.core.config.loader.LangConfigLoader
-import io.github.durun.nitron.core.parser.antlr.AstBuildVisitor
-import io.github.durun.nitron.core.parser.antlr.ParserStore
-import io.github.durun.nitron.core.parser.antlr.nodeTypePoolOf
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import java.nio.file.Paths
 
 class AstNormalizerTest : FreeSpec({
 	val config = LangConfigLoader.load(Paths.get("config/lang/java.json"))
-	val parser = ParserStore.getOrThrow(config.grammar)
-	val javaAst = parser.parse(javaCode.reader(), config.grammar.startRule)
-		.accept(AstBuildVisitor("java", parser.antlrParser))
-	val types = nodeTypePoolOf("java", parser.antlrParser)
+    val parser = config.grammar.getParser()
+    val javaAst = parser.parse(javaCode.reader())
+    val types = parser.nodeTypes
 
-	"simple path" {
-		val ast = javaAst.copy()
-		println(ast)
-		val normalizer = AstNormalizer(
-			mapOf(AstPath.of("IntegerLiteral", types) to "N"),
-			numberedMapping = mapOf(AstPath.of("//expressionName", types) to "V"),
-			ignoreRules = listOf(AstPath.of("EOF", types))
-		)
-		val normalized = normalizer.process(ast)
-		println(normalized)
-		normalized.toString() shouldBe normalizedCode1
-	}
-	"path ifThenStatement/expression" {
-		val ast = javaAst.copy()
-		println(ast)
-		val normalizer = AstNormalizer(
-			mapOf(AstPath.of("//ifThenStatement/expression") to "COND"),
-			numberedMapping = emptyMap(),
-			ignoreRules = listOf()
-		)
-		val normalized = normalizer.process(ast)
-		println(normalized)
-		normalized.toString() shouldBe normalizedCode2
-	}
+    "simple path" {
+        val ast = javaAst.copy()
+        println(ast)
+        val normalizer = AstNormalizer(
+            mapOf(AstPath.of("IntegerLiteral", types) to "N"),
+            numberedMapping = mapOf(AstPath.of("//expressionName", types) to "V"),
+            ignoreRules = listOf(AstPath.of("EOF", types))
+        )
+        val normalized = normalizer.process(ast)
+        println(normalized)
+        normalized.toString() shouldBe normalizedCode1
+    }
+    "path ifThenStatement/expression" {
+        val ast = javaAst.copy()
+        println(ast)
+        val normalizer = AstNormalizer(
+            mapOf(AstPath.of("//ifThenStatement/expression") to "COND"),
+            numberedMapping = emptyMap(),
+            ignoreRules = listOf()
+        )
+        val normalized = normalizer.process(ast)
+        println(normalized)
+        normalized.toString() shouldBe normalizedCode2
+    }
 })
 
 private const val javaCode = """

--- a/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
@@ -7,7 +7,7 @@ import java.nio.file.Paths
 
 class AstSplitterTest : FreeSpec({
     val config = LangConfigLoader.load(Paths.get("config/lang/java.json"))
-    val parser = config.grammar.getParser()
+    val parser = config.parserConfig.getParser()
     val javaAst = parser.parse(javaCode.reader())
     val types = parser.nodeTypes
 

--- a/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
@@ -14,9 +14,9 @@ class AstSplitterTest : FreeSpec({
     "split statement" {
         val ast = javaAst.copy()
         println(ast)
-        config.process.splitConfig.splitRules
+        config.processConfig.splitConfig.splitRules
         val splitter = AstSplitter(
-            config.process.splitConfig.splitRules.mapNotNull { types.getType(it) }
+            config.processConfig.splitConfig.splitRules.mapNotNull { types.getType(it) }
         )
         val splitted = splitter.process(ast)
         println(splitted)

--- a/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
@@ -1,19 +1,15 @@
 package io.github.durun.nitron.core.ast.processors
 
 import io.github.durun.nitron.core.config.loader.LangConfigLoader
-import io.github.durun.nitron.core.parser.antlr.AstBuildVisitor
-import io.github.durun.nitron.core.parser.antlr.ParserStore
-import io.github.durun.nitron.core.parser.antlr.nodeTypePoolOf
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import java.nio.file.Paths
 
 class AstSplitterTest : FreeSpec({
     val config = LangConfigLoader.load(Paths.get("config/lang/java.json"))
-    val parser = ParserStore.getOrThrow(config.grammar)
-    val javaAst = parser.parse(javaCode.reader(), config.grammar.startRule)
-        .accept(AstBuildVisitor("java", parser.antlrParser))
-    val types = nodeTypePoolOf("java", parser.antlrParser)
+    val parser = config.grammar.getParser()
+    val javaAst = parser.parse(javaCode.reader())
+    val types = parser.nodeTypes
 
     "split statement" {
         val ast = javaAst.copy()

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/GenericParserTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/GenericParserTest.kt
@@ -1,6 +1,6 @@
 package io.github.durun.nitron.core.parser.antlr
 
-import io.github.durun.nitron.core.config.GrammarConfig
+import io.github.durun.nitron.core.config.AntlrParserConfig
 import io.github.durun.nitron.core.config.loader.NitronConfigLoader
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FreeSpec
@@ -15,7 +15,7 @@ class GenericParserTest : FreeSpec({
     include(
         tests(
             "javascript",
-            config.langConfig["javascript"]!!.grammar,
+            config.langConfig["javascript"]!!.grammar as AntlrParserConfig,
             src = """console.log("Hello");"""
         )
     )
@@ -23,7 +23,7 @@ class GenericParserTest : FreeSpec({
     include(
         tests(
             "csharp",
-            config.langConfig["csharp"]!!.grammar,
+            config.langConfig["csharp"]!!.grammar as AntlrParserConfig,
             src = """
 				class HelloClass {
 				    void hello() { }
@@ -33,17 +33,17 @@ class GenericParserTest : FreeSpec({
     )
 })
 
-private fun tests(name: String, config: GrammarConfig, src: String) = freeSpec {
-	val parser by lazy {
-		GenericParser.fromFiles(
-				config.grammarFilePaths,
-				utilityJavaFiles = config.utilJavaFilePaths
-		)
-	}
-	name - {
-		"init" {
-			shouldNotThrowAny {
-				println(parser)
+private fun tests(name: String, config: AntlrParserConfig, src: String) = freeSpec {
+    val parser by lazy {
+        GenericParser.fromFiles(
+            config.grammarFilePaths,
+            utilityJavaFiles = config.utilJavaFilePaths
+        )
+    }
+    name - {
+        "init" {
+            shouldNotThrowAny {
+                println(parser)
 			}
 		}
 		"antlrParser" {

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/GenericParserTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/GenericParserTest.kt
@@ -15,7 +15,7 @@ class GenericParserTest : FreeSpec({
     include(
         tests(
             "javascript",
-            config.langConfig["javascript"]!!.grammar as AntlrParserConfig,
+            config.langConfig["javascript"]!!.parserConfig as AntlrParserConfig,
             src = """console.log("Hello");"""
         )
     )
@@ -23,7 +23,7 @@ class GenericParserTest : FreeSpec({
     include(
         tests(
             "csharp",
-            config.langConfig["csharp"]!!.grammar as AntlrParserConfig,
+            config.langConfig["csharp"]!!.parserConfig as AntlrParserConfig,
             src = """
 				class HelloClass {
 				    void hello() { }

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
@@ -1,7 +1,7 @@
 package io.github.durun.nitron.core.parser.antlr
 
 import io.github.durun.nitron.core.config.AntlrParserConfig
-import io.github.durun.nitron.core.config.GrammarConfig
+import io.github.durun.nitron.core.config.ParserConfig
 import io.kotest.mpp.log
 import java.nio.file.Path
 
@@ -16,7 +16,7 @@ object ParserStore {
         }
     }
 
-    fun getOrThrow(config: GrammarConfig): GenericParser = getOrThrow(config as AntlrParserConfig)
+    fun getOrThrow(config: ParserConfig): GenericParser = getOrThrow(config as AntlrParserConfig)
     fun getOrThrow(config: AntlrParserConfig): GenericParser =
         getOrThrow(config.grammarFilePaths, config.utilJavaFilePaths)
 
@@ -27,7 +27,7 @@ object ParserStore {
         }.getOrThrow()
     }
 
-    fun getOrNull(config: GrammarConfig): GenericParser? = getOrNull(config as AntlrParserConfig)
+    fun getOrNull(config: ParserConfig): GenericParser? = getOrNull(config as AntlrParserConfig)
     fun getOrNull(config: AntlrParserConfig): GenericParser? =
         getOrNull(config.grammarFilePaths, config.utilJavaFilePaths)
 

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
@@ -1,33 +1,40 @@
 package io.github.durun.nitron.core.parser.antlr
 
+import io.github.durun.nitron.core.config.AntlrParserConfig
 import io.github.durun.nitron.core.config.GrammarConfig
 import io.kotest.mpp.log
 import java.nio.file.Path
 
 object ParserStore {
-	private val parsers = mutableMapOf<Pair<Set<Path>, Set<Path>?>, Result<GenericParser>>()
+    private val parsers = mutableMapOf<Pair<Set<Path>, Set<Path>?>, Result<GenericParser>>()
 
-	private val mapping: (Pair<Set<Path>, Set<Path>>) -> Result<GenericParser> = { (grammarFiles, utilityJavaFiles) ->
-		runCatching {
-			val p = GenericParser.fromFiles(grammarFiles, utilityJavaFiles)
+    private val mapping: (Pair<Set<Path>, Set<Path>>) -> Result<GenericParser> = { (grammarFiles, utilityJavaFiles) ->
+        runCatching {
+            val p = GenericParser.fromFiles(grammarFiles, utilityJavaFiles)
             log { "Compiled grammar: ${p.antlrParser.grammarFileName}" }
             p
-		}
-	}
+        }
+    }
 
-	fun getOrThrow(config: GrammarConfig): GenericParser = getOrThrow(config.grammarFilePaths, config.utilJavaFilePaths)
-	fun getOrThrow(grammarFiles: Collection<Path>, utilJavaFiles: Collection<Path> = emptySet()): GenericParser {
-		val key = grammarFiles.toSet() to utilJavaFiles.toSet()
-		return synchronized(parsers) {
-			parsers.computeIfAbsent(key) { mapping(key) }
-		}.getOrThrow()
-	}
+    fun getOrThrow(config: GrammarConfig): GenericParser = getOrThrow(config as AntlrParserConfig)
+    fun getOrThrow(config: AntlrParserConfig): GenericParser =
+        getOrThrow(config.grammarFilePaths, config.utilJavaFilePaths)
 
-	fun getOrNull(config: GrammarConfig): GenericParser? = getOrNull(config.grammarFilePaths, config.utilJavaFilePaths)
-	fun getOrNull(grammarFiles: Collection<Path>, utilJavaFiles: Collection<Path> = emptySet()): GenericParser? {
-		val key = grammarFiles.toSet() to utilJavaFiles.toSet()
-		return synchronized(parsers) {
-			parsers.computeIfAbsent(key) { mapping(key) }
-		}.getOrNull()
-	}
+    fun getOrThrow(grammarFiles: Collection<Path>, utilJavaFiles: Collection<Path> = emptySet()): GenericParser {
+        val key = grammarFiles.toSet() to utilJavaFiles.toSet()
+        return synchronized(parsers) {
+            parsers.computeIfAbsent(key) { mapping(key) }
+        }.getOrThrow()
+    }
+
+    fun getOrNull(config: GrammarConfig): GenericParser? = getOrNull(config as AntlrParserConfig)
+    fun getOrNull(config: AntlrParserConfig): GenericParser? =
+        getOrNull(config.grammarFilePaths, config.utilJavaFilePaths)
+
+    fun getOrNull(grammarFiles: Collection<Path>, utilJavaFiles: Collection<Path> = emptySet()): GenericParser? {
+        val key = grammarFiles.toSet() to utilJavaFiles.toSet()
+        return synchronized(parsers) {
+            parsers.computeIfAbsent(key) { mapping(key) }
+        }.getOrNull()
+    }
 }

--- a/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
@@ -1,5 +1,6 @@
 package io.github.durun.nitron.test
 
+import io.github.durun.nitron.core.config.AntlrParserConfig
 import io.github.durun.nitron.core.config.LangConfig
 import io.github.durun.nitron.core.config.loader.NitronConfigLoader
 import io.github.durun.nitron.core.parser.antlr.ParserStore
@@ -30,9 +31,10 @@ class LangTest : FreeSpec({
 @ExperimentalPathApi
 fun langTestFactory(lang: String, config: LangConfig) = freeSpec {
 	"config for $lang (${config.fileName})" - {
-		val parser = ParserStore.getOrNull(config.grammar)
+        val parser = ParserStore.getOrNull(config.grammar)
+        val parserConfig = config.grammar as AntlrParserConfig
 		"grammar files exist" {
-			val files = config.grammar.grammarFilePaths + config.grammar.utilJavaFilePaths
+            val files = parserConfig.grammarFilePaths + parserConfig.utilJavaFilePaths
             log { "${config.fileName}: files=$files" }
             files shouldHaveAtLeastSize 1
             files.forAll {
@@ -45,7 +47,7 @@ fun langTestFactory(lang: String, config: LangConfig) = freeSpec {
 			}
 		}
 		"defines start rule" {
-            val startRule = config.grammar.startRule
+            val startRule = parserConfig.startRule
             log { "${config.fileName}: startRule=$startRule" }
             startRule shouldBeIn parser!!.antlrParser.ruleNames
         }
@@ -68,7 +70,7 @@ fun langTestFactory(lang: String, config: LangConfig) = freeSpec {
 			runCatching {
 				allowedRules shouldContainAll usedRules
 			}.onFailure {
-				println("see: ${config.grammar.grammarFilePaths.map(Path::normalize)}")
+                println("see: ${parserConfig.grammarFilePaths.map(Path::normalize)}")
 				val errorSymbols = (usedRules - allowedRules)
 				config.filePath.bufferedReader().lineSequence().forEachIndexed { index, line ->
 					val file = config.filePath

--- a/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
@@ -22,9 +22,9 @@ import kotlin.io.path.bufferedReader
 @ExperimentalPathApi
 class LangTest : FreeSpec({
 	val configPath = Paths.get("config/nitron.json")
-	NitronConfigLoader.load(configPath).langConfig.forEach { (lang, config) ->
-		include(langTestFactory(lang, config))
-	}
+    NitronConfigLoader.load(configPath).langConfig
+        .filter { (_, config) -> config.grammar is AntlrParserConfig }
+        .forEach { (lang, config) -> include(langTestFactory(lang, config)) }
 })
 
 

--- a/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
@@ -58,10 +58,10 @@ fun langTestFactory(lang: String, config: LangConfig) = freeSpec {
         }
 		"uses correct rule/token name" {
 			val usedRules: List<String> = (
-                    config.process.normalizeConfig.ignoreRules +
-                            config.process.normalizeConfig.mapping.keys +
-                            config.process.normalizeConfig.indexedMapping.keys +
-                            config.process.splitConfig.splitRules
+                    config.processConfig.normalizeConfig.ignoreRules +
+                            config.processConfig.normalizeConfig.mapping.keys +
+                            config.processConfig.normalizeConfig.indexedMapping.keys +
+                            config.processConfig.splitConfig.splitRules
                     )
                 .flatMap { it.split('/').filter(String::isNotEmpty) }
                 .filterNot { it.contains(Regex("[^a-zA-Z]")) }

--- a/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/LangTest.kt
@@ -23,7 +23,7 @@ import kotlin.io.path.bufferedReader
 class LangTest : FreeSpec({
 	val configPath = Paths.get("config/nitron.json")
     NitronConfigLoader.load(configPath).langConfig
-        .filter { (_, config) -> config.grammar is AntlrParserConfig }
+        .filter { (_, config) -> config.parserConfig is AntlrParserConfig }
         .forEach { (lang, config) -> include(langTestFactory(lang, config)) }
 })
 
@@ -31,19 +31,19 @@ class LangTest : FreeSpec({
 @ExperimentalPathApi
 fun langTestFactory(lang: String, config: LangConfig) = freeSpec {
 	"config for $lang (${config.fileName})" - {
-        val parser = ParserStore.getOrNull(config.grammar)
-        val parserConfig = config.grammar as AntlrParserConfig
-		"grammar files exist" {
+        val parser = ParserStore.getOrNull(config.parserConfig)
+        val parserConfig = config.parserConfig as AntlrParserConfig
+        "grammar files exist" {
             val files = parserConfig.grammarFilePaths + parserConfig.utilJavaFilePaths
             log { "${config.fileName}: files=$files" }
             files shouldHaveAtLeastSize 1
             files.forAll {
                 it.shouldBeReadable()
             }
-		}
-		"defines parser settings" {
-			shouldNotThrowAny {
-				ParserStore.getOrThrow(config.grammar)
+        }
+        "defines parser settings" {
+            shouldNotThrowAny {
+                ParserStore.getOrThrow(config.parserConfig)
 			}
 		}
 		"defines start rule" {

--- a/src/test/kotlin/io/github/durun/nitron/test/StructuresDBTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/StructuresDBTest.kt
@@ -40,7 +40,7 @@ class StructuresDBTest : FreeSpec() {
 		db = SQLiteDatabase.connect(path)
 		langConfig = LangConfigLoader.load(langPath)
 		processor = CodeProcessor(langConfig, outputPath = path.parent.resolve("test.structures"))
-		val antlrParser = ParserStore.getOrThrow(langConfig.grammar).antlrParser
+		val antlrParser = ParserStore.getOrThrow(langConfig.parserConfig).antlrParser
 		nodeTypePool = nodeTypePoolOf(langConfig.fileName, antlrParser)
 
 		"prepare" - {

--- a/src/test/kotlin/io/github/durun/nitron/validation/configTemplate.kt
+++ b/src/test/kotlin/io/github/durun/nitron/validation/configTemplate.kt
@@ -18,7 +18,7 @@ fun main() = TemporaryTest {
     "LangConfig" - {
         "ANTLR Grammar" {
             val config = LangConfig(
-                grammarConfig = AntlrParserConfig(emptyList(), emptyList(), "startRule"),
+                parser = AntlrParserConfig(emptyList(), emptyList(), "startRule"),
                 processConfig = ProcessConfig(
                     SplitConfig(emptyList()),
                     NormalizeConfig(emptyMap(), emptyMap(), emptyList())

--- a/src/test/kotlin/io/github/durun/nitron/validation/configTemplate.kt
+++ b/src/test/kotlin/io/github/durun/nitron/validation/configTemplate.kt
@@ -1,0 +1,35 @@
+package io.github.durun.nitron.validation
+
+import io.github.durun.nitron.core.config.*
+import io.github.durun.nitron.core.config.loader.KSerializationConfigLoader
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+
+
+fun main() = TemporaryTest {
+    "NitronConfig" {
+        val config = NitronConfig(emptyMap())
+        val loader = KSerializationConfigLoader(NitronConfig.serializer())
+        val json = loader.json.encodeToJsonElement(config)
+        println()
+        println(json)
+        loader.json.decodeFromJsonElement(json)
+    }
+    "LangConfig" - {
+        "ANTLR Grammar" {
+            val config = LangConfig(
+                grammarConfig = AntlrParserConfig(emptyList(), emptyList(), "startRule"),
+                processConfig = ProcessConfig(
+                    SplitConfig(emptyList()),
+                    NormalizeConfig(emptyMap(), emptyMap(), emptyList())
+                ),
+                extensions = emptyList()
+            )
+            val loader = KSerializationConfigLoader(NitronConfig.serializer())
+            val json = loader.json.encodeToJsonElement(config)
+            println()
+            println(json)
+            loader.json.decodeFromJsonElement(json)
+        }
+    }
+}.execute()

--- a/src/test/kotlin/io/github/durun/nitron/validation/javaSpeedTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/validation/javaSpeedTest.kt
@@ -3,7 +3,6 @@ package io.github.durun.nitron.validation
 import io.github.durun.nitron.core.ast.visitor.AstPrintVisitor
 import io.github.durun.nitron.core.config.loader.NitronConfigLoader
 import io.github.durun.nitron.core.parser.AstBuilders
-import io.github.durun.nitron.core.parser.antlr.antlr
 import io.github.durun.nitron.core.parser.jdt.jdt
 import java.nio.file.Paths
 import kotlin.time.ExperimentalTime
@@ -28,9 +27,8 @@ fun main(args: Array<String>) = TemporaryTest {
         }
     }
     "ANTLR" {
-        val config = NitronConfigLoader.load(configPath).langConfig["java"]?.grammar ?: throw Exception()
-        val parser =
-            AstBuilders.antlr(config.fileName, config.startRule, config.grammarFilePaths, config.utilJavaFilePaths)
+        val config = NitronConfigLoader.load(configPath).langConfig["java"]?.parserConfig ?: throw Exception()
+        val parser = config.getParser()
         sources.forEach { src ->
             val time = measureTime {
                 parser.parse(src.reader())


### PR DESCRIPTION
## 設定ファイルのフォーマット変更
### パーサのタイプを指定可能に
ANTLRなら`"type": "antlr"`, JDT Parserなら `"type": "jdt"`のように指定する。
https://github.com/Durun/nitron/blob/d68991b30232a58f4e159bc3908b4160f2b0bfa6/config/lang/cpp.json#L9

### 項目名の変更
`grammarConfig` → `parserConfig` とする。
https://github.com/Durun/nitron/blob/d68991b30232a58f4e159bc3908b4160f2b0bfa6/config/lang/cpp.json#L8-L16