### PR TITLE
JDT Parser用の抽出ルールを追加

### DIFF
--- a/config/lang/java-jdt.json
+++ b/config/lang/java-jdt.json
@@ -1,0 +1,23 @@
+{
+  "extensions": [
+	".java"
+  ],
+  "parserConfig": {
+	"type": "jdt",
+	"version": "16"
+  },
+  "processConfig": {
+	"splitConfig": {
+	  "splitRules": [
+	  ]
+	},
+	"normalizeConfig": {
+	  "mapping": {
+	  },
+	  "indexedMapping": {
+	  },
+	  "ignoreRules": [
+	  ]
+	}
+  }
+}

--- a/config/lang/java-jdt.json
+++ b/config/lang/java-jdt.json
@@ -9,14 +9,42 @@
   "processConfig": {
 	"splitConfig": {
 	  "splitRules": [
+		"TYPE_DECLARATION",
+		"METHOD_DECLARATION",
+		"FIELD_DECLARATION",
+		"EXPRESSION_STATEMENT",
+		"VARIABLE_DECLARATION_STATEMENT",
+		"TRY_STATEMENT",
+		"CATCH_CLAUSE",
+		"WHILE_STATEMENT",
+		"DO_STATEMENT",
+		"FOR_STATEMENT",
+		"IF_STATEMENT",
+		"SWITCH_STATEMENT",
+		"SWITCH_CASE",
+		"BREAK_STATEMENT",
+		"SYNCHRONIZED_STATEMENT",
+		"RETURN_STATEMENT",
+		"THROW_STATEMENT"
 	  ]
 	},
 	"normalizeConfig": {
 	  "mapping": {
+		"STRING_LITERAL": "\"S\"",
+		"CHARACTER_LITERAL": "'C'",
+		"NUMBER_LITERAL": "N",
+		"BOOLEAN_LITERAL": "$L"
 	  },
 	  "indexedMapping": {
+		"//SIMPLE_NAME[..[@tag!='QUALIFIED_NAME' and @tag!='METHOD_DECLARATION' and @tag!='TYPE_DECLARATION'] and not(following::TOKEN[1]='(') and not(preceding-sibling::TOKEN[1]='.')]": "$V",
+		"//SIMPLE_NAME[..[@tag='QUALIFIED_NAME'] and position()=1 and not(preceding-sibling::TOKEN[1]='.')]": "$V"
 	  },
 	  "ignoreRules": [
+		"PACKAGE_DECLARATION",
+		"IMPORT_DECLARATION",
+		"MODIFIER",
+		"MARKER_ANNOTATION",
+		"//TOKEN[.='}']"
 	  ]
 	}
   }

--- a/config/lang/java.json
+++ b/config/lang/java.json
@@ -12,19 +12,25 @@
 	"processConfig": {
 		"splitConfig": {
 			"splitRules": [
-			  "blockStatement",
-			  "labeledStatement",
+			  "typeDeclaration",
+			  "methodDeclaration",
+			  "classBodyDeclaration",
+			  "expressionStatement",
+			  "localVariableDeclarationStatement",
+			  "tryStatement",
+			  "catchClause",
+			  "whileStatement",
+			  "doStatement",
+			  "forStatement",
 			  "ifThenStatement",
 			  "ifThenElseStatement",
-			  "whileStatement",
-			  "forStatement",
+			  "switchStatement",
 			  "switchLabel",
-			  "labeledStatementNoShortIf",
-			  "whileStatementNoShortIf",
-			  "forStatementNoShortIf",
-			  "catchClause",
-			  "typeDeclaration",
-			  "classBodyDeclaration"
+			  "breakStatement",
+			  "synchronizedStatement",
+			  "returnStatement",
+			  "throwStatement",
+			  "assertStatement"
 			]
 		},
 		"normalizeConfig": {

--- a/config/lang/java.json
+++ b/config/lang/java.json
@@ -12,11 +12,19 @@
 	"processConfig": {
 		"splitConfig": {
 			"splitRules": [
-				"statement",
-				"ELSE",
-				"catchClause",
-				"typeDeclaration",
-				"methodDeclaration"
+			  "blockStatement",
+			  "labeledStatement",
+			  "ifThenStatement",
+			  "ifThenElseStatement",
+			  "whileStatement",
+			  "forStatement",
+			  "switchLabel",
+			  "labeledStatementNoShortIf",
+			  "whileStatementNoShortIf",
+			  "forStatementNoShortIf",
+			  "catchClause",
+			  "typeDeclaration",
+			  "classBodyDeclaration"
 			]
 		},
 		"normalizeConfig": {

--- a/config/nitron.json
+++ b/config/nitron.json
@@ -1,6 +1,7 @@
 {
     "langConfigFiles": {
 	  "java": "lang/java.json",
+	  "java-jdt": "lang/java-jdt.json",
 	  "kotlin": "lang/kotlin.json",
 	  "python": "lang/python.json",
 	  "cpp": "lang/cpp.json",

--- a/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/config/ParserConfig.kt
@@ -4,6 +4,7 @@ import io.github.durun.nitron.core.MD5
 import io.github.durun.nitron.core.parser.AstBuilder
 import io.github.durun.nitron.core.parser.AstBuilders
 import io.github.durun.nitron.core.parser.antlr.antlr
+import io.github.durun.nitron.core.parser.jdt.jdt
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.nio.file.Path
@@ -43,4 +44,13 @@ data class AntlrParserConfig(
             .reduce { a, b -> a + b }
             .let { MD5.digest(it) }
     }
+}
+
+@Serializable
+@SerialName("jdt")
+data class JdtParserConfig(
+    val version: String
+) : ParserConfig() {
+    override fun getParser(): AstBuilder = AstBuilders.jdt(version)
+    override fun checksum(): MD5 = MD5.digest("JDT Parser $version")
 }

--- a/src/main/kotlin/io/github/durun/nitron/core/parser/jdt/JdtAstBuilder.kt
+++ b/src/main/kotlin/io/github/durun/nitron/core/parser/jdt/JdtAstBuilder.kt
@@ -20,7 +20,7 @@ import java.io.Reader
 
 
 @Suppress("UNUSED")
-fun AstBuilders.jdt(): AstBuilder = JdtAstBuilder()
+fun AstBuilders.jdt(version: String = JavaCore.VERSION_16): AstBuilder = JdtAstBuilder(version)
 
 private class JdtAstBuilder(version: String = JavaCore.VERSION_16) : AstBuilder {
     override val nodeTypes: NodeTypePool = Companion.nodeTypes

--- a/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/ast/processors/AstSplitterTest.kt
@@ -36,8 +36,7 @@ public class HelloWorld {
 
 private const val splittedCode = """public class HelloWorld {
 public static void main ( String [ ] args ) {
-if ( false )
-{
+if ( false ) {
 x = y * x + 1 ;
 }
 }

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/GenericParserTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/GenericParserTest.kt
@@ -34,12 +34,7 @@ class GenericParserTest : FreeSpec({
 })
 
 private fun tests(name: String, config: AntlrParserConfig, src: String) = freeSpec {
-    val parser by lazy {
-        GenericParser.fromFiles(
-            config.grammarFilePaths,
-            utilityJavaFiles = config.utilJavaFilePaths
-        )
-    }
+    val parser = ParserStore.getOrThrow(config)
     name - {
         "init" {
             shouldNotThrowAny {

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
@@ -6,26 +6,19 @@ import io.kotest.mpp.log
 import java.nio.file.Path
 
 object ParserStore {
-    private val parsers = mutableMapOf<Pair<Set<Path>, Set<Path>?>, Result<GenericParser>>()
+    private val parsers = mutableMapOf<Pair<Set<Path>, Set<Path>>, GenericParser>()
 
-    private val mapping: (Pair<Set<Path>, Set<Path>>) -> Result<GenericParser> = { (grammarFiles, utilityJavaFiles) ->
-        runCatching {
-            val p = GenericParser.fromFiles(grammarFiles, utilityJavaFiles)
-            log { "Compiled grammar: ${p.antlrParser.grammarFileName}" }
-            p
-        }
-    }
-
+    fun getOrNull(config: ParserConfig): GenericParser? = runCatching { getOrThrow(config) }.getOrNull()
     fun getOrThrow(config: ParserConfig): GenericParser = getOrThrow(config as AntlrParserConfig)
     fun getOrThrow(config: AntlrParserConfig): GenericParser =
         getOrThrow(config.grammarFilePaths, config.utilJavaFilePaths)
-
     fun getOrThrow(grammarFiles: Collection<Path>, utilJavaFiles: Collection<Path> = emptySet()): GenericParser {
-        val key = grammarFiles.toSet() to utilJavaFiles.toSet()
         return synchronized(parsers) {
-            parsers.computeIfAbsent(key) { mapping(key) }
-        }.getOrThrow()
+            parsers.computeIfAbsent(grammarFiles.toSet() to utilJavaFiles.toSet()) { (gFiles, uFiles) ->
+                val parser = GenericParser.fromFiles(gFiles, uFiles)
+                log { "Compiled grammar: ${parser.antlrParser.grammarFileName}" }
+                parser
+            }
+        }
     }
-
-    fun getOrNull(config: ParserConfig): GenericParser? = runCatching { getOrThrow(config) }.getOrNull()
 }

--- a/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
+++ b/src/test/kotlin/io/github/durun/nitron/core/parser/antlr/ParserStore.kt
@@ -27,14 +27,5 @@ object ParserStore {
         }.getOrThrow()
     }
 
-    fun getOrNull(config: ParserConfig): GenericParser? = getOrNull(config as AntlrParserConfig)
-    fun getOrNull(config: AntlrParserConfig): GenericParser? =
-        getOrNull(config.grammarFilePaths, config.utilJavaFilePaths)
-
-    fun getOrNull(grammarFiles: Collection<Path>, utilJavaFiles: Collection<Path> = emptySet()): GenericParser? {
-        val key = grammarFiles.toSet() to utilJavaFiles.toSet()
-        return synchronized(parsers) {
-            parsers.computeIfAbsent(key) { mapping(key) }
-        }.getOrNull()
-    }
+    fun getOrNull(config: ParserConfig): GenericParser? = runCatching { getOrThrow(config) }.getOrNull()
 }

--- a/src/test/kotlin/io/github/durun/nitron/test/CodeProcessorTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/test/CodeProcessorTest.kt
@@ -64,7 +64,8 @@ private const val javaParsed = """package sample ; import some . Library ; publi
 private const val javaSplitted = """package sample ; import some . Library ;
 public class HelloWorld {
 public static void main ( String [ ] args ) {
-try { URL url = null ;
+try {
+URL url = null ;
 try {
 url = new URL ( source ) ;
 url = url + "test" ;
@@ -79,8 +80,7 @@ throw e ;
 if ( true ) {
 System . out . println ( "Hello-A" ) ;
 } else
-if ( false )
-{
+if ( false ) {
 System . out . println ( "Hello-B" ) ;
 }
 }
@@ -88,7 +88,8 @@ System . out . println ( "Hello-B" ) ;
 <EOF>"""
 private const val javaNormalized = """class HelloWorld {
 void main ( String [ ] ${"$"}V0 ) {
-try { URL ${"$"}V0 = null ;
+try {
+URL ${"$"}V0 = null ;
 try {
 ${"$"}V0 = new URL ( ${"$"}V1 ) ;
 ${"$"}V0 = ${"$"}V0 + "S" ;
@@ -99,6 +100,5 @@ throw ${"$"}V0 ;
 if ( ${"$"}L ) {
 ${"$"}V0 . println ( "S" ) ;
 else
-if ( ${"$"}L )
-{
+if ( ${"$"}L ) {
 ${"$"}V0 . println ( "S" ) ;"""

--- a/src/test/kotlin/io/github/durun/nitron/validation/TemporaryTest.kt
+++ b/src/test/kotlin/io/github/durun/nitron/validation/TemporaryTest.kt
@@ -1,23 +1,34 @@
 package io.github.durun.nitron.validation
 
-class TemporaryTest(private val testBody: TemporaryTest.() -> Unit) {
-	fun execute(): Unit = testBody()
+import java.io.PrintStream
 
-	private val ignorePrefix = "!"
+class TemporaryTest(
+    private val output: PrintStream = System.out,
+    private val testBody: TemporaryTest.() -> Unit
+) {
+    fun execute(): Unit = testBody()
 
-	fun addTestCase(name: String, ignore: Boolean = false, test: () -> Unit) {
-		if (name.startsWith(ignorePrefix)) return addTestCase(name.drop(ignorePrefix.length), ignore = true, test = test)
-		print("$name: ")
-		if (ignore) {
-			println("Ignored")
-			return
+    private val ignorePrefix = "!"
+
+    fun addTestCase(name: String, ignore: Boolean = false, test: () -> Unit) {
+        if (name.startsWith(ignorePrefix)) return addTestCase(
+            name.drop(ignorePrefix.length),
+            ignore = true,
+            test = test
+        )
+        output.println("### $name")
+        if (ignore) {
+            output.println("Ignored")
+            return
 		}
-		runCatching { test() }
-				.onSuccess { println("OK") }
+        runCatching { test() }
+            .onSuccess { output.println("OK") }
 				.onFailure {
-					println("Failed: ${it.message}")
-					it.printStackTrace(System.err)
-				}
+                    output.println("Failed: ${it.message}")
+                    output.println("```")
+                    it.printStackTrace(output)
+                    output.println("```")
+                }
 	}
 
 	infix operator fun String.invoke(test: () -> Unit) = addTestCase(this, test = test)
@@ -25,14 +36,22 @@ class TemporaryTest(private val testBody: TemporaryTest.() -> Unit) {
 	fun addTestCaseDir(name: String, ignore: Boolean = false, test: TemporaryTest.() -> Unit) {
 		if (name.startsWith(ignorePrefix)) return addTestCaseDir(name.drop(ignorePrefix.length), ignore = true, test = test)
 		if (ignore) {
-			println("[$name]: Ignored")
-			return
-		} else {
-			println("[$name]")
-		}
-		runCatching { test() }
-				.onFailure { it.printStackTrace(System.err) }
-	}
+            output.println("## [$name]\n Ignored")
+            return
+        } else {
+            output.println("## [$name]")
+        }
+        runCatching { test() }
+            .onFailure { it.printStackTrace(output) }
+    }
 
-	infix operator fun String.minus(test: TemporaryTest.() -> Unit) = addTestCaseDir(this, test = test)
+    infix operator fun String.minus(test: TemporaryTest.() -> Unit) = addTestCaseDir(this, test = test)
+}
+
+fun testReportAsMarkDown(testBody: TemporaryTest.() -> Unit) {
+    val file = kotlin.io.path.createTempFile(suffix = ".md")
+    println("Test start.")
+    TemporaryTest(output = PrintStream(file.toFile()), testBody = testBody)
+        .execute()
+    println("Test finished: ${file.toUri()}")
 }

--- a/src/test/kotlin/io/github/durun/nitron/validation/java-jdt.kt
+++ b/src/test/kotlin/io/github/durun/nitron/validation/java-jdt.kt
@@ -1,0 +1,357 @@
+package io.github.durun.nitron.validation
+
+import io.github.durun.nitron.binding.cpanalyzer.CodeProcessor
+import io.github.durun.nitron.core.config.loader.NitronConfigLoader
+import io.kotest.matchers.shouldBe
+import java.nio.file.Paths
+
+
+private val configPath = Paths.get("config/nitron.json")
+private val javaConfig = NitronConfigLoader.load(configPath).langConfig["java-jdt"] ?: throw Exception()
+
+private val processor = CodeProcessor(javaConfig)
+
+fun main() = testReportAsMarkDown {
+    "package" - {
+        "ignore package" {
+            "package sample;".normalize() shouldBe emptyList()
+        }
+        "ignore import" {
+            """ package sample;
+                import org.sample.GodClass;
+            """.trimIndent().normalize() shouldBe emptyList()
+        }
+    }
+    "class" - {
+        "extract class declaration" {
+            """ package sample;
+                class SampleClass {
+                }
+                """.trimIndent().normalize() shouldBe listOf(
+                "class SampleClass {"
+            )
+        }
+        "ignore modifier" {
+            """ package sample;
+                public class SampleClass {
+                }
+                """.trimIndent().normalize() shouldBe listOf(
+                "class SampleClass {"
+            )
+        }
+        "extract method declaration" {
+            code().normalize() shouldBe normStatements(null)
+        }
+    }
+    "normalize literals" - {
+        "string" {
+            code(methodBody = """call("hello");""").normalize() shouldBe normStatements(methodBody = """call ( "S" ) ;""")
+        }
+        "char" {
+            code(methodBody = "call('A');").normalize() shouldBe normStatements(methodBody = "call ( 'C' ) ;")
+        }
+        "integer" {
+            code(methodBody = "call(123);").normalize() shouldBe normStatements(methodBody = "call ( N ) ;")
+        }
+        "long" {
+            code(methodBody = "call(123L);").normalize() shouldBe normStatements(methodBody = "call ( N ) ;")
+        }
+        "floating point" {
+            code(methodBody = "call(3.14);").normalize() shouldBe normStatements(methodBody = "call ( N ) ;")
+            code(methodBody = "call(3.14f);").normalize() shouldBe normStatements(methodBody = "call ( N ) ;")
+        }
+        "boolean" {
+            code(methodBody = "call(true);").normalize() shouldBe normStatements(methodBody = "call ( \$L ) ;")
+            code(methodBody = "call(false);").normalize() shouldBe normStatements(methodBody = "call ( \$L ) ;")
+        }
+    }
+    "normalize variables" - {
+        "assignment" {
+            code(methodBody = "x = f();").normalize() shouldBe normStatements(methodBody = "\$V0 = f ( ) ;")
+        }
+        "variable declaration" {
+            code(methodBody = "int x = f();").normalize() shouldBe normStatements(methodBody = "int \$V0 = f ( ) ;")
+            code(methodBody = "int x, y;").normalize() shouldBe normStatements(methodBody = "int \$V0 , \$V1 ;")
+        }
+        "argument" {
+            code(methodBody = "f(a1);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 ) ;")
+        }
+        "correct variable index" {
+            code(methodBody = "f(a0, a1, a0, a2);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 , \$V1 , \$V0 , \$V2 ) ;")
+        }
+        "expression" {
+            code(methodBody = "f((x+y)*z);").normalize() shouldBe normStatements(methodBody = "f ( ( \$V0 + \$V1 ) * \$V2 ) ;")
+        }
+        "member field access" {
+            code(methodBody = "f(m.name);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 . name ) ;")
+            code(methodBody = "f(m.name.length);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 . name . length) ;")
+        }
+        "member method access" {
+            code(methodBody = "m.toString();").normalize() shouldBe normStatements(methodBody = "\$V0 . toString ( ) ;")
+            code(methodBody = "m.name.toString();").normalize() shouldBe normStatements(methodBody = "\$V0 . name . toString ( ) ;")
+        }
+    }
+    "split statements" - {
+        "expression statements" {
+            code(
+                methodBody = """
+                invoke1();
+                invoke2();
+            """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "invoke1 ( ) ;",
+                    "invoke2 ( ) ;"
+                )
+            )
+        }
+        "try-catch statements" {
+            code(
+                methodBody = """
+                try {
+                  invoke1();
+                } catch (Exception e) {
+                  invoke2();
+                }
+            """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "try {",
+                    "invoke1 ( ) ;",
+                    "catch ( Exception \$V0 ) {",
+                    "invoke2 ( ) ;"
+                )
+            )
+        }
+        "try-catch-finally statements" {
+            code(
+                methodBody = """
+                try {
+                  invoke1();
+                } catch (Exception e) {
+                  invoke2();
+                } finally {
+                  invoke3();
+                }
+            """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "try {",
+                    "invoke1 ( ) ;",
+                    "catch ( Exception \$V0 ) {",
+                    "invoke2 ( ) ;",
+                    "finally {",
+                    "invoke3 ( ) ;"
+                )
+            )
+        }
+        "while statement" {
+            code(methodBody = "while(cond) invoke();").normalize() shouldBe normStatements(methodBody = "while ( \$V0 ) invoke ( ) ;")
+        }
+        "while block" {
+            code(
+                methodBody = """
+                while(cond) {
+                  invoke();
+                }
+                """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "while ( \$V0 ) {",
+                    "invoke ( ) ;"
+                )
+            )
+        }
+        "do-while block" {
+            code(
+                methodBody = """
+                do {
+                  invoke();
+                }while(cond);
+                """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "do {",
+                    "invoke ( ) ;",
+                    "while ( \$V0 ) ;",
+                )
+            )
+        }
+        "for statement" {
+            code(methodBody = "for(int i=0; i<5; i++) invoke();").normalize() shouldBe normStatements(
+                methodBody = "for ( int \$V0 = N ; \$V0 < N ; \$V0 ++ ) invoke ( ) ;"
+            )
+        }
+        "for block" {
+            code(
+                methodBody = """
+                for(int i=0; i<5; i++) {
+                  invoke();
+                  continue;
+                }
+                """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "for ( int \$V0 = N ; \$V0 < N ; \$V0 ++ ) {",
+                    "invoke ( ) ;",
+                    "continue ;"
+                )
+            )
+        }
+        "if statement" {
+            code(methodBody = "if(cond) invoke();").normalize() shouldBe normStatements(methodBody = "if ( \$V0 ) invoke ( ) ;")
+        }
+        "if block" {
+            code(
+                methodBody = """
+                    if(cond) {
+                      invoke1();
+                      invoke2();
+                    }
+                """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "if ( \$V0 ) {",
+                    "invoke1 ( ) ;",
+                    "invoke2 ( ) ;"
+                )
+            )
+        }
+        "if-else statement" {
+            code(methodBody = "if (cond) f1(); else f2();").normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "if ( \$V0 ) f1 ( ) ; else f2 ( ) ;"
+                )
+            )
+        }
+        "if-else block" {
+            code(methodBody = "if (cond) { f1(); } else { f2(); }").normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "if ( \$V0 ) {",
+                    "f1 ( ) ;",
+                    "else {",
+                    "f2 ( ) ;"
+                )
+            )
+        }
+        "else-if statement" {
+            code(methodBody = "if (cond0) f1(); else if (cond1) f2();").normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "if ( \$V0 ) f1 ( ) ; else",
+                    "if ( \$V0 ) f2 ( ) ;"
+                )
+            )
+        }
+        "switch statement" {
+            code(
+                methodBody = """
+                    switch(a) {
+                      case 1:
+                      break;
+                      default:
+                    }
+                """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "switch ( \$V0 ) {",
+                    "case N :",
+                    "break ;",
+                    "default :"
+                )
+            )
+        }
+        "synchronized statement" {
+            code(
+                methodBody = """
+                    synchronized(l) {
+                      invoke();
+                    }
+                """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "synchronized ( \$V0 ) {",
+                    "invoke ( ) ;"
+                )
+            )
+        }
+        "return statement" {
+            code(methodBody = "return invoke();").normalize() shouldBe normStatements(methodBody = "return invoke ( ) ;")
+        }
+        "assert statement" {
+            code(methodBody = "assert invoke();").normalize() shouldBe normStatements(methodBody = "assert invoke ( ) ;")
+        }
+        "throw statement" {
+            code(methodBody = "throw e;").normalize() shouldBe normStatements(methodBody = "throw \$V0 ;")
+        }
+    }
+    "ignoring" - {
+        "package declaration" {
+            "package sample;".normalize() shouldBe emptyList()
+        }
+        "import declaration" {
+            "import org.sample.GodClass;".normalize() shouldBe emptyList()
+        }
+        "annotation" {
+            code(
+                classBody = """
+                    @Deprecated
+                    void func() { }
+            """.trimIndent()
+            ).normalize() shouldBe normStatements(
+                classBody = listOf(
+                    "void func ( ) {"
+                )
+            )
+        }
+        "modifier" {
+            code(methodBody = "final int x = 0;").normalize() shouldBe normStatements(methodBody = "int \$V0 = N ;")
+            "public class SampleClass {}".normalize() shouldBe listOf("class SampleClass {")
+            code(classBody = "private int x = 0;").normalize() shouldBe normStatements(classBody = "int \$V0 = N ;")
+            code(classBody = "private void f(){}").normalize() shouldBe normStatements(classBody = "void f ( ) {")
+            code(classBody = "private SampleClass(){}").normalize() shouldBe normStatements(classBody = "SampleClass ( ) {")
+        }
+    }
+}
+
+
+private fun code(
+    classBody: String = "",
+    methodBody: String = ""
+): String {
+    return """package sample;
+        import org.sample.GodClass;
+        class SampleClass {
+          $classBody
+          public static void main() {
+          $methodBody
+          } 
+        }
+    """.trimIndent()
+}
+
+private fun normStatements(
+    classBody: List<String> = emptyList(),
+    methodBody: List<String> = emptyList()
+): List<String> {
+    return listOf(
+        "class SampleClass {",
+        *classBody.toTypedArray(),
+        "void main ( ) {",
+        *methodBody.toTypedArray()
+    )
+}
+
+private fun normStatements(
+    classBody: String? = null,
+    methodBody: String? = null
+) = normStatements(listOfNotNull(classBody), listOfNotNull(methodBody))
+
+private fun String.toStatements(): List<String> {
+    return processor.split(this)
+        .map { it.getText() }
+}
+
+private fun String.normalize(): List<String> {
+    return processor.split(this)
+        .mapNotNull { processor.proceess(it)?.getText() }
+}

--- a/src/test/kotlin/io/github/durun/nitron/validation/java-jdt.kt
+++ b/src/test/kotlin/io/github/durun/nitron/validation/java-jdt.kt
@@ -2,6 +2,7 @@ package io.github.durun.nitron.validation
 
 import io.github.durun.nitron.binding.cpanalyzer.CodeProcessor
 import io.github.durun.nitron.core.ast.visitor.AstPrintVisitor
+import io.github.durun.nitron.core.ast.visitor.AstXmlBuildVisitor
 import io.github.durun.nitron.core.config.loader.NitronConfigLoader
 import io.kotest.matchers.shouldBe
 import java.nio.file.Paths
@@ -78,7 +79,7 @@ fun main() = testReportAsMarkDown {
         }
         "member field access" {
             code(methodBody = "f(m.name);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 . name ) ;")
-            code(methodBody = "f(m.name.length);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 . name . length) ;")
+            code(methodBody = "f(m.name.length);").normalize() shouldBe normStatements(methodBody = "f ( \$V0 . name . length ) ;")
         }
         "member method access" {
             code(methodBody = "m.toString();").normalize() shouldBe normStatements(methodBody = "\$V0 . toString ( ) ;")
@@ -140,7 +141,12 @@ fun main() = testReportAsMarkDown {
             )
         }
         "while statement" {
-            code(methodBody = "while(cond) invoke();").normalize() shouldBe normStatements(methodBody = "while ( \$V0 ) invoke ( ) ;")
+            code(methodBody = "while(cond) invoke();").normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "while ( \$V0 )",
+                    "invoke ( ) ;"
+                )
+            )
         }
         "while block" {
             code(
@@ -173,7 +179,10 @@ fun main() = testReportAsMarkDown {
         }
         "for statement" {
             code(methodBody = "for(int i=0; i<5; i++) invoke();").normalize() shouldBe normStatements(
-                methodBody = "for ( int \$V0 = N ; \$V0 < N ; \$V0 ++ ) invoke ( ) ;"
+                methodBody = listOf(
+                    "for ( int \$V0 = N ; \$V0 < N ; \$V0 ++ )",
+                    "invoke ( ) ;"
+                )
             )
         }
         "for block" {
@@ -193,7 +202,12 @@ fun main() = testReportAsMarkDown {
             )
         }
         "if statement" {
-            code(methodBody = "if(cond) invoke();").normalize() shouldBe normStatements(methodBody = "if ( \$V0 ) invoke ( ) ;")
+            code(methodBody = "if(cond) invoke();").normalize() shouldBe normStatements(
+                methodBody = listOf(
+                    "if ( \$V0 )",
+                    "invoke ( ) ;"
+                )
+            )
         }
         "if block" {
             code(
@@ -214,7 +228,10 @@ fun main() = testReportAsMarkDown {
         "if-else statement" {
             code(methodBody = "if (cond) f1(); else f2();").normalize() shouldBe normStatements(
                 methodBody = listOf(
-                    "if ( \$V0 ) f1 ( ) ; else f2 ( ) ;"
+                    "if ( \$V0 )",
+                    "f1 ( ) ;",
+                    "else",
+                    "f2 ( ) ;"
                 )
             )
         }
@@ -231,8 +248,11 @@ fun main() = testReportAsMarkDown {
         "else-if statement" {
             code(methodBody = "if (cond0) f1(); else if (cond1) f2();").normalize() shouldBe normStatements(
                 methodBody = listOf(
-                    "if ( \$V0 ) f1 ( ) ; else",
-                    "if ( \$V0 ) f2 ( ) ;"
+                    "if ( \$V0 )",
+                    "f1 ( ) ;",
+                    "else",
+                    "if ( \$V0 )",
+                    "f2 ( ) ;"
                 )
             )
         }
@@ -344,5 +364,6 @@ private fun String.normalize(): List<String> {
     return processor.split(this)
         .mapNotNull { processor.proceess(it) }
         .onEach { println(it.accept(AstPrintVisitor)) }
+        .onEach { println(it.accept(AstXmlBuildVisitor)) }
         .map { it.getText() }
 }


### PR DESCRIPTION
#106 

## XPath解説
https://github.com/Durun/nitron/blob/ecce46fb4f6a7bdd02064dfe5ab14626cdac92ee/config/lang/java-jdt.json#L38-L41
### ルール1
```
//SIMPLE_NAME[..[@tag!='QUALIFIED_NAME' and @tag!='METHOD_DECLARATION' and @tag!='TYPE_DECLARATION'] and not(following::TOKEN[1]='(') and not(preceding-sibling::TOKEN[1]='.')]
```
`@tag!='QUALIFIED_NAME'` -> ルール2の対象でない
`@tag!='METHOD_DECLARATION'` -> メソッド名でない
`@tag!='TYPE_DECLARATION'` -> クラス名でない
`not(following::TOKEN[1]='(')` -> メソッド名でない
`not(preceding-sibling::TOKEN[1]='.')` -> フィールドでない

### ルール2
```
//SIMPLE_NAME[..[@tag='QUALIFIED_NAME'] and position()=1 and not(preceding-sibling::TOKEN[1]='.')]
```
変数からフィールドへのアクセスを正規化する。
フィールド名は残す。
例) `v.name.length` -> `$V0.name.length`