### PR TITLE
メトリクス計算コマンドの分割・styleOnlyメトリクスの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A multilingual code normalizer application/library.
 nitron is distributed through [JitPack](https://jitpack.io)
 
 ```groovy
-implementation 'com.github.Durun:nitron:0.3'
+implementation 'com.github.Durun:nitron:v0.3'
 ```
 
 [nitron as a library Guide (Japanese)](README_Lib_jp.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 group = "com.github.durun.nitron"
-version = "0.2-SNAPSHOT"
+version = "v0.3"
 
 buildscript {
     val kotlinVersion = "1.5.21"

--- a/src/main/kotlin/com/github/durun/nitron/app/App.kt
+++ b/src/main/kotlin/com/github/durun/nitron/app/App.kt
@@ -2,6 +2,7 @@ package com.github.durun.nitron.app
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
+import com.github.durun.nitron.app.metrics.AdditionalMetricsCommand
 import com.github.durun.nitron.app.metrics.MetricsCommand
 import com.github.durun.nitron.app.preparse.FetchCommand
 import com.github.durun.nitron.app.preparse.ParseCommand
@@ -24,6 +25,7 @@ fun main(args: Array<String>) {
         RegisterCommand(),
         FetchCommand(),
         ParseCommand(),
-        MetricsCommand()
+        MetricsCommand(),
+        AdditionalMetricsCommand(),
     ).main(args)
 }

--- a/src/main/kotlin/com/github/durun/nitron/app/metrics/AdditionalMetricsCommand.kt
+++ b/src/main/kotlin/com/github/durun/nitron/app/metrics/AdditionalMetricsCommand.kt
@@ -1,0 +1,155 @@
+package com.github.durun.nitron.app.metrics
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.types.path
+import com.github.durun.nitron.core.toMD5
+import com.github.durun.nitron.inout.database.SQLiteDatabase
+import com.github.durun.nitron.inout.model.metrics.ChangesTable
+import com.github.durun.nitron.inout.model.metrics.CodesTable
+import com.github.durun.nitron.inout.model.metrics.GlobalPatternsTable
+import com.github.durun.nitron.inout.model.metrics.MetricsTable
+import com.github.durun.nitron.util.Log
+import com.github.durun.nitron.util.LogLevel
+import com.github.durun.nitron.util.logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.nio.file.Path
+import kotlin.math.ln
+
+class AdditionalMetricsCommand : CliktCommand(name = "additionalMetrics") {
+    private val dbFiles: List<Path> by argument(name = "DATABASE", help = "Database file")
+        .path(mustBeReadable = true)
+        .multiple()
+
+    private val log by logger()
+
+    override fun run() {
+        LogLevel = Log.Level.VERBOSE
+        dbFiles.forEach { dbFile ->
+            val db = SQLiteDatabase.connect(dbFile)
+            processOneDb(db)
+            log.info { "Done: $dbFile" }
+        }
+    }
+
+    private fun processOneDb(db: Database) {
+        log.info { "Reading DB" }
+
+        val metrices = transaction(db) {
+            val c1 = CodesTable.alias("c1")
+            val c2 = CodesTable.alias("c2")
+            GlobalPatternsTable
+                .innerJoin(c1, onColumn = { beforeHash }, otherColumn = { c1[CodesTable.hash] })
+                .innerJoin(c2, onColumn = { GlobalPatternsTable.afterHash }, otherColumn = { c2[CodesTable.hash] })
+                .selectAll()
+                .mapIndexed { i, it ->
+                    val blob = it[GlobalPatternsTable.beforeHash] to it[GlobalPatternsTable.afterHash]
+                    val hash = blob.first?.toMD5() to blob.second?.toMD5()
+
+                    if (i % 1000 == 0) log.info { "Read: $i" }
+
+                    Metrics(
+                        pattern = Pattern(
+                            hash, blob, text = it[c1[CodesTable.text]] to it[c2[CodesTable.text]]
+                        ),
+                        support = it[GlobalPatternsTable.support],
+                        confidence = it[GlobalPatternsTable.confidence],
+                        projects = it[GlobalPatternsTable.projects],
+                        files = it[GlobalPatternsTable.files],
+                        authors = it[GlobalPatternsTable.authors],
+                        bugfixWords = it[GlobalPatternsTable.bugfixWords],
+                        testFiles = it[GlobalPatternsTable.testFiles]
+                    )
+                }
+        }
+        log.debug { "nPatterns: ${metrices.size}" }
+
+
+        val softwares = transaction(db) {
+            ChangesTable.slice(ChangesTable.software)
+                .selectAll()
+                .distinct()
+                .map { it[ChangesTable.software] }
+        }
+        log.debug { "Softwares: $softwares" }
+
+        val nFiles = transaction(db) {
+            ChangesTable.slice(ChangesTable.filepath)
+                .selectAll()
+                .distinct()
+                .count()
+        }
+
+        val additionalMetrices = runBlocking(Dispatchers.Default) {
+            metrices.mapIndexed { i, metrics ->
+                async {
+                    val beforeText = metrics.pattern.text.first
+                    val afterText = metrics.pattern.text.second
+                    val beforeTokens = beforeText.split(' ')
+                    val afterTokens = afterText.split(' ')
+
+
+                    if (i % 1000 == 0) log.info { "Calc done: $i / ${metrices.size}" }
+
+                    AdditionalMetrics(
+                        pattern = metrics.pattern,
+                        projectIdf = ln(softwares.size.toDouble() / metrics.projects),
+                        fileIdf = ln(nFiles.toDouble() / metrics.files),
+                        dChars = afterText.length - beforeText.length,
+                        dTokens = afterTokens.size - beforeTokens.size,
+                        changeToLessThan = countChangeToLessThan(beforeTokens, afterTokens),
+                        styleOnly = isStyleOnlyChange(beforeText, afterText)
+                    )
+                }
+            }.map { it.await() }
+        }
+
+        log.info { "Calc done." }
+        log.info { "Writing to DB." }
+
+        transaction(db) {
+            SchemaUtils.drop(MetricsTable)
+            SchemaUtils.createMissingTablesAndColumns(MetricsTable)
+        }
+        transaction(db) {
+            MetricsTable.batchInsert(additionalMetrices, ignore = true) {
+                this[MetricsTable.beforeHash] = it.pattern.blob.first
+                this[MetricsTable.afterHash] = it.pattern.blob.second
+                this[MetricsTable.projectIdf] = it.projectIdf
+                this[MetricsTable.fileIdf] = it.fileIdf
+                this[MetricsTable.dChars] = it.dChars
+                this[MetricsTable.dTokens] = it.dTokens
+                this[MetricsTable.changeToLessThan] = it.changeToLessThan
+                this[MetricsTable.styleOnly] = if (it.styleOnly) 1 else 0
+            }
+        }
+    }
+
+    companion object {
+        fun countChangeToLessThan(beforeTokens: List<String>, afterTokens: List<String>): Int {
+            val beforeLt = beforeTokens.count { it == "<" || it == "<=" }
+            val afterLt = afterTokens.count { it == "<" || it == "<=" }
+            val beforeGt = beforeTokens.count { it == ">" || it == ">=" }
+            val afterGt = afterTokens.count { it == ">" || it == ">=" }
+            val dLessThan = afterLt - beforeLt
+            val dGreaterThan = afterGt - beforeGt
+            return if (dLessThan == -dGreaterThan) dLessThan else 0
+        }
+
+        fun isStyleOnlyChange(beforeText: String, afterText: String): Boolean {
+            val (inner, outer) = when {
+                beforeText.startsWith(afterText) -> afterText to beforeText
+                afterText.startsWith(beforeText) -> beforeText to afterText
+                else -> return false
+            }
+            val suffix = outer.drop(inner.length)
+                .trim()
+            return suffix == "{"
+        }
+    }
+}

--- a/src/main/kotlin/com/github/durun/nitron/app/metrics/AdditionalMetricsCommand.kt
+++ b/src/main/kotlin/com/github/durun/nitron/app/metrics/AdditionalMetricsCommand.kt
@@ -51,7 +51,7 @@ class AdditionalMetricsCommand : CliktCommand(name = "additionalMetrics") {
                     val blob = it[GlobalPatternsTable.beforeHash] to it[GlobalPatternsTable.afterHash]
                     val hash = blob.first?.toMD5() to blob.second?.toMD5()
 
-                    if (i % 1000 == 0) log.info { "Read: $i" }
+                    if (i % 100000 == 0) log.info { "Read: $i" }
 
                     Metrics(
                         pattern = Pattern(
@@ -73,14 +73,19 @@ class AdditionalMetricsCommand : CliktCommand(name = "additionalMetrics") {
         val softwares = transaction(db) {
             ChangesTable.slice(ChangesTable.software)
                 .selectAll()
-                .distinct()
+                .withDistinct(true)
+                .asSequence()
                 .map { it[ChangesTable.software] }
+                .distinct()
+                .toList()
         }
         log.debug { "Softwares: $softwares" }
 
         val nFiles = transaction(db) {
             ChangesTable.slice(ChangesTable.filepath)
                 .selectAll()
+                .withDistinct(true)
+                .asSequence()
                 .distinct()
                 .count()
         }
@@ -94,7 +99,7 @@ class AdditionalMetricsCommand : CliktCommand(name = "additionalMetrics") {
                     val afterTokens = afterText.split(' ')
 
 
-                    if (i % 1000 == 0) log.info { "Calc done: $i / ${metrices.size}" }
+                    if (i % 100000 == 0) log.info { "Calc done: $i / ${metrices.size}" }
 
                     AdditionalMetrics(
                         pattern = metrics.pattern,

--- a/src/main/kotlin/com/github/durun/nitron/app/metrics/models.kt
+++ b/src/main/kotlin/com/github/durun/nitron/app/metrics/models.kt
@@ -1,0 +1,49 @@
+package com.github.durun.nitron.app.metrics
+
+import com.github.durun.nitron.core.MD5
+import java.sql.Blob
+
+
+data class Pattern(
+    val hash: Pair<MD5?, MD5?>,
+    val blob: Pair<Blob?, Blob?>,
+    val text: Pair<String, String>
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Pattern
+
+        if (hash != other.hash) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return hash.hashCode()
+    }
+}
+
+data class Metrics(
+    val pattern: Pattern,
+
+    val support: Int,
+    val confidence: Double,
+    val projects: Int,
+    val files: Int,
+    val authors: Int,
+    val bugfixWords: Double,// コミットメッセージに bugfix keyword が含まれているchangesの数
+    val testFiles: Double,  // テストコードであるchangesの数
+)
+
+data class AdditionalMetrics(
+    val pattern: Pattern,
+
+    val projectIdf: Double,
+    val fileIdf: Double,
+    val dChars: Int,    // Pattern前後の文字数の増減
+    val dTokens: Int,   // Pattern前後のトークン数の増減
+    val changeToLessThan: Int,  // >, >= から <, <= への変更がされた数
+    val styleOnly: Boolean, // 違いは { を挿入するかだけか?
+)

--- a/src/main/kotlin/com/github/durun/nitron/inout/model/metrics/metricsTables.kt
+++ b/src/main/kotlin/com/github/durun/nitron/inout/model/metrics/metricsTables.kt
@@ -34,14 +34,27 @@ object GlobalPatternsTable : Table("globalPatterns") {
     val support: Column<Int> = integer("support")
     val confidence: Column<Double> = double("confidence")
     val projects: Column<Int> = integer("projects")
-    val projectIdf: Column<Double> = double("projectIdf")
     val files: Column<Int> = integer("files")
-    val fileIdf: Column<Double> = double("fileIdf")
-    val dChars: Column<Int> = integer("dChars")
-    val dTokens: Column<Int> = integer("dTokens")
     val authors: Column<Int> = integer("authors")
     val bugfixWords: Column<Double> = double("bugfixWords")
     val testFiles: Column<Double> = double("testFiles")
+    // TODO: more metrics
+}
+
+
+/**
+ * GlobalPatternsTableが計算済みなら高速に計算可能なメトリクス
+ */
+object MetricsTable : Table("metrics") {
+    // id
+    val beforeHash: Column<Blob?> = blob("beforeHash").nullable()
+    val afterHash: Column<Blob?> = blob("afterHash").nullable()
+
+    // metrics
+    val projectIdf: Column<Double> = double("projectIdf")
+    val fileIdf: Column<Double> = double("fileIdf")
+    val dChars: Column<Int> = integer("dChars")
+    val dTokens: Column<Int> = integer("dTokens")
     val changeToLessThan: Column<Int> = integer("changeToLessThan")
     val styleOnly: Column<Int> = integer("styleOnly")
     // TODO: more metrics

--- a/src/main/kotlin/com/github/durun/nitron/inout/model/metrics/metricsTables.kt
+++ b/src/main/kotlin/com/github/durun/nitron/inout/model/metrics/metricsTables.kt
@@ -43,5 +43,6 @@ object GlobalPatternsTable : Table("globalPatterns") {
     val bugfixWords: Column<Double> = double("bugfixWords")
     val testFiles: Column<Double> = double("testFiles")
     val changeToLessThan: Column<Int> = integer("changeToLessThan")
+    val styleOnly: Column<Int> = integer("styleOnly")
     // TODO: more metrics
 }

--- a/src/test/kotlin/com/github/durun/nitron/app/metrics/MetricsCommandTest.kt
+++ b/src/test/kotlin/com/github/durun/nitron/app/metrics/MetricsCommandTest.kt
@@ -5,10 +5,10 @@ import io.kotest.matchers.shouldBe
 
 class MetricsCommandTest : FreeSpec({
     "isStyleOnlyChange" {
-        MetricsCommand.isStyleOnlyChange("if (cond)", "if (cond) {") shouldBe true
-        MetricsCommand.isStyleOnlyChange("if (cond) {", "if (cond)") shouldBe true
-        MetricsCommand.isStyleOnlyChange("if (cond)", "if (cond)\n{") shouldBe true
-        MetricsCommand.isStyleOnlyChange("if (cond1)", "if (cond2) {") shouldBe false
-        MetricsCommand.isStyleOnlyChange("if (cond1) {", "if (cond2)") shouldBe false
+        AdditionalMetricsCommand.isStyleOnlyChange("if (cond)", "if (cond) {") shouldBe true
+        AdditionalMetricsCommand.isStyleOnlyChange("if (cond) {", "if (cond)") shouldBe true
+        AdditionalMetricsCommand.isStyleOnlyChange("if (cond)", "if (cond)\n{") shouldBe true
+        AdditionalMetricsCommand.isStyleOnlyChange("if (cond1)", "if (cond2) {") shouldBe false
+        AdditionalMetricsCommand.isStyleOnlyChange("if (cond1) {", "if (cond2)") shouldBe false
     }
 })

--- a/src/test/kotlin/com/github/durun/nitron/app/metrics/MetricsCommandTest.kt
+++ b/src/test/kotlin/com/github/durun/nitron/app/metrics/MetricsCommandTest.kt
@@ -1,0 +1,14 @@
+package com.github.durun.nitron.app.metrics
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class MetricsCommandTest : FreeSpec({
+    "isStyleOnlyChange" {
+        MetricsCommand.isStyleOnlyChange("if (cond)", "if (cond) {") shouldBe true
+        MetricsCommand.isStyleOnlyChange("if (cond) {", "if (cond)") shouldBe true
+        MetricsCommand.isStyleOnlyChange("if (cond)", "if (cond)\n{") shouldBe true
+        MetricsCommand.isStyleOnlyChange("if (cond1)", "if (cond2) {") shouldBe false
+        MetricsCommand.isStyleOnlyChange("if (cond1) {", "if (cond2)") shouldBe false
+    }
+})


### PR DESCRIPTION
- `nitron metrics`コマンド
  - 基本的なメトリクスを計算する
- `nitron additionalMetrics`コマンド
  - 事前に`nitron metrics`が実行されていることを前提に、計算に時間のかからないメトリクスを計算する 