### PR TITLE
AstLineGetVisitorが返す型をLineRangeへ変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A multilingual code normalizer application/library.
 nitron is distributed through [JitPack](https://jitpack.io)
 
 ```groovy
-implementation 'com.github.Durun:nitron:v0.3'
+implementation 'com.github.Durun:nitron:v0.4'
 ```
 
 [nitron as a library Guide (Japanese)](README_Lib_jp.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 group = "com.github.durun.nitron"
-version = "v0.3"
+version = "v0.4"
 
 buildscript {
     val kotlinVersion = "1.5.21"

--- a/src/main/kotlin/com/github/durun/nitron/core/ast/visitor/AstLineGetVisitor.kt
+++ b/src/main/kotlin/com/github/durun/nitron/core/ast/visitor/AstLineGetVisitor.kt
@@ -8,12 +8,12 @@ import com.github.durun.nitron.core.ast.node.AstTerminalNode
  * Line numberの範囲を求めるビジター。
  * ただし、正規化する前のAstNodeにacceptさせなければならない。
  */
-object AstLineGetVisitor : AstVisitor<IntRange> {
-    override fun visit(node: AstNode): IntRange {
+object AstLineGetVisitor : AstVisitor<LineRange> {
+    override fun visit(node: AstNode): LineRange {
         TODO("Not yet implemented")
     }
 
-    override fun visitRule(node: AstRuleNode): IntRange {
+    override fun visitRule(node: AstRuleNode): LineRange {
         val first = node.children?.first()
             ?: throw Exception("Can't get line number from normalized AstNode")
         val last = node.children?.last()
@@ -23,11 +23,13 @@ object AstLineGetVisitor : AstVisitor<IntRange> {
             firstRange
         } else {
             val lastRange = last.accept(this)
-            firstRange.first..lastRange.last
+            LineRange(firstRange.first, lastRange.last)
         }
     }
 
-    override fun visitTerminal(node: AstTerminalNode): IntRange {
-        return node.line..node.line
+    override fun visitTerminal(node: AstTerminalNode): LineRange {
+        return LineRange(node.line, node.line)
     }
 }
+
+data class LineRange(val first: Int, val last: Int)

--- a/src/test/kotlin/com/github/durun/nitron/core/ast/visitor/AstLineGetVisitorTest.kt
+++ b/src/test/kotlin/com/github/durun/nitron/core/ast/visitor/AstLineGetVisitorTest.kt
@@ -31,8 +31,8 @@ class AstLineGetVisitorTest : FreeSpec({
         )
         val tree = nodeOf(rule, *children)
 
-        tree.accept(AstLineGetVisitor) shouldBe 0..5
-        tree.children[0].accept(AstLineGetVisitor) shouldBe 0..0
-        tree.children[1].accept(AstLineGetVisitor) shouldBe 1..4
+        tree.accept(AstLineGetVisitor) shouldBe LineRange(0, 5)
+        tree.children[0].accept(AstLineGetVisitor) shouldBe LineRange(0, 0)
+        tree.children[1].accept(AstLineGetVisitor) shouldBe LineRange(1, 4)
     }
 })


### PR DESCRIPTION
JavaはIntRangeに対応していないため、LineRangeクラスを作り、それを返すようにした