### PR TITLE
javaCompile時の警告を抑制

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
     // Use the Kotlin JDK 8 standard library.
-    implementation(kotlin("stdlib-jdk8"))
+    api(kotlin("stdlib-jdk8"))
 
     //// Dependency for parsing
     // Java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 group = "com.github.durun.nitron"
-version = "v0.4"
+version = "v0.6"
 
 buildscript {
     val kotlinVersion = "1.5.21"


### PR DESCRIPTION
Javaからnitronを使用してビルドする際の以下のような警告を抑制
```
warning: unknown enum constant DeprecationLevel.HIDDEN
  reason: class file for kotlin.DeprecationLevel not found
```

kotlin-stdlib の class file がJava側に公開されていなかったのが原因